### PR TITLE
Fix admin validation for admin only pages

### DIFF
--- a/Areas/Admin/Controllers/CategoryController.cs
+++ b/Areas/Admin/Controllers/CategoryController.cs
@@ -6,6 +6,7 @@
 
     using Constants;
     using Contracts;
+    using Infrastructure;
     using Models.Categories;
     using techIE.Controllers;
 
@@ -35,9 +36,7 @@
 
         public IActionResult Add()
         {
-            // It's no issue that userId may be null.
-            // IsAdminAsync returns false if no users' ID matches the provided one.
-            if (!userService.IsAdminAsync(User.FindFirst(ClaimTypes.NameIdentifier)?.Value))
+            if (!this.User.IsAdmin())
             {
                 return Unauthorized();
             }
@@ -54,9 +53,7 @@
         [HttpPost]
         public async Task<IActionResult> Add(CategoryFormViewModel model)
         {
-            // It's no issue that userId may be null.
-            // IsAdminAsync returns false if no users' ID matches the provided one.
-            if (!userService.IsAdminAsync(User.FindFirst(ClaimTypes.NameIdentifier)?.Value))
+            if (!this.User.IsAdmin())
             {
                 return Unauthorized();
             }
@@ -80,9 +77,7 @@
         [HttpGet]
         public async Task<IActionResult> Edit(int id)
         {
-            // It's no issue that userId may be null.
-            // IsAdminAsync returns false if no users' ID matches the provided one.
-            if (!userService.IsAdminAsync(User.FindFirst(ClaimTypes.NameIdentifier)?.Value))
+            if (!this.User.IsAdmin())
             {
                 return Unauthorized();
             }
@@ -106,6 +101,11 @@
         [HttpPost]
         public async Task<IActionResult> Edit(CategoryFormViewModel model)
         {
+            if (!this.User.IsAdmin())
+            {
+                return Unauthorized();
+            }
+
             if (!ModelState.IsValid)
             {
                 return View(model);
@@ -124,7 +124,7 @@
         /// <returns></returns>
         public async Task<IActionResult> Verify(int id)
         {
-            if (!userService.IsAdminAsync(User.FindFirst(ClaimTypes.NameIdentifier)?.Value))
+            if (!this.User.IsAdmin())
             {
                 return Unauthorized();
             }
@@ -147,7 +147,7 @@
         /// <returns>Returns to panel page if successful.</returns>
         public async Task<IActionResult> Delete(int id)
         {
-            if (!userService.IsAdminAsync(User.FindFirst(ClaimTypes.NameIdentifier)?.Value))
+            if (!this.User.IsAdmin())
             {
                 return Unauthorized();
             }

--- a/Areas/Admin/Controllers/PanelController.cs
+++ b/Areas/Admin/Controllers/PanelController.cs
@@ -5,6 +5,7 @@
     using Microsoft.AspNetCore.Mvc;
 
     using Contracts;
+    using Infrastructure;
     using techIE.Controllers;
 
     /// <summary>
@@ -36,9 +37,7 @@
         [HttpGet]
         public IActionResult Index()
         {
-            // It's no issue that userId may be null.
-            // IsAdminAsync returns false if no users' ID matches the provided one.
-            if (!userService.IsAdminAsync(User.FindFirst(ClaimTypes.NameIdentifier)?.Value))
+            if (!this.User.IsAdmin())
             {
                 return Unauthorized();
             }
@@ -53,9 +52,7 @@
         [HttpGet]
         public async Task<IActionResult> Categories()
         {
-            // It's no issue that userId may be null.
-            // IsAdminAsync returns false if no users' ID matches the provided one.
-            if (!userService.IsAdminAsync(User.FindFirst(ClaimTypes.NameIdentifier)?.Value))
+            if (!this.User.IsAdmin())
             {
                 return Unauthorized();
             }
@@ -71,9 +68,7 @@
         [HttpGet]
         public async Task<IActionResult> Products()
         {
-            // It's no issue that userId may be null.
-            // IsAdminAsync returns false if no users' ID matches the provided one.
-            if (!userService.IsAdminAsync(User.FindFirst(ClaimTypes.NameIdentifier)?.Value))
+            if (!this.User.IsAdmin())
             {
                 return Unauthorized();
             }

--- a/Areas/Admin/Controllers/ProductController.cs
+++ b/Areas/Admin/Controllers/ProductController.cs
@@ -6,6 +6,7 @@
 
     using Constants;
     using Contracts;
+    using Infrastructure;
     using Models.Products;
     using techIE.Controllers;
 
@@ -37,9 +38,7 @@
         [HttpGet]
         public async Task<IActionResult> Add()
         {
-            // It's no issue that userId may be null.
-            // IsAdminAsync returns false if no users' ID matches the provided one.
-            if (!userService.IsAdminAsync(User.FindFirst(ClaimTypes.NameIdentifier)?.Value))
+            if (!this.User.IsAdmin())
             {
                 return Unauthorized();
             }
@@ -61,9 +60,7 @@
         [HttpPost]
         public async Task<IActionResult> Add(ProductFormViewModel model)
         {
-            // It's no issue that userId may be null.
-            // IsAdminAsync returns false if no users' ID matches the provided one.
-            if (!userService.IsAdminAsync(User.FindFirst(ClaimTypes.NameIdentifier)?.Value))
+            if (!this.User.IsAdmin())
             {
                 return Unauthorized();
             }
@@ -88,9 +85,7 @@
         [HttpGet]
         public async Task<IActionResult> Edit(int id)
         {
-            // It's no issue that userId may be null.
-            // IsAdminAsync returns false if no users' ID matches the provided one.
-            if (!userService.IsAdminAsync(User.FindFirst(ClaimTypes.NameIdentifier)?.Value))
+            if (!this.User.IsAdmin())
             {
                 return Unauthorized();
             }
@@ -122,6 +117,11 @@
         [HttpPost]
         public async Task<IActionResult> Edit(ProductFormViewModel model)
         {
+            if (!this.User.IsAdmin())
+            {
+                return Unauthorized();
+            }
+
             if (!ModelState.IsValid)
             {
                 model.Categories = await categoryService.GetOfficialAsync();
@@ -141,7 +141,7 @@
         /// <returns>Returns to panel page if successful.</returns>
         public async Task<IActionResult> Delete(int id)
         {
-            if (!userService.IsAdminAsync(User.FindFirst(ClaimTypes.NameIdentifier)?.Value))
+            if (!this.User.IsAdmin())
             {
                 return Unauthorized();
             }

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -27,7 +27,7 @@
     <header>
         <nav id="navbar" class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
             <div class="container-fluid">
-                <a class="navbar-brand" asp-controller="Home" asp-action="Index">tech<span class="logo-i">I</span><span class="logo-e">E</span></a>
+                <a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index">tech<span class="logo-i">I</span><span class="logo-e">E</span></a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse" aria-controls="navbarSupportedContent"
                         aria-expanded="false" aria-label="Toggle navigation">
                     <span class="navbar-toggler-icon"></span>

--- a/Views/Shared/_LoginPartial.cshtml
+++ b/Views/Shared/_LoginPartial.cshtml
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="~/css/dropdowns/dropdown-with-animations.css" />
 </head>
 
-<ul class="navbar-nav">
+<ul class="navbar-nav user-dropdown">
 @if (SignInManager.IsSignedIn(User))
 {
     <li class="nav-item position-fixed user-greet">

--- a/wwwroot/css/dropdowns/dropdown-with-animations.css
+++ b/wwwroot/css/dropdowns/dropdown-with-animations.css
@@ -1,19 +1,18 @@
-﻿ul li {
+﻿.user-dropdown ul li {
     list-style: none;
     display: inline-block;
     text-decoration: none;
-    text-align: center;
 }
 
-li a {
+.user-dropdown li a {
     color: black;
 }
 
-li a:hover {
-    color: #3ca0e7;
+.user-dropdown li a:hover {
+    color: cornflowerblue;
 }
 
-li:hover {
+.user-dropdown li:hover {
     cursor: pointer;
 }
 


### PR DESCRIPTION
Add a validation, using our ClaimsPrincipalExtension, to check if the current user is an admin. If they are, they can access the admin actions.