### PR TITLE
Fix redirect paths for admin area

### DIFF
--- a/Areas/Admin/Controllers/CategoryController.cs
+++ b/Areas/Admin/Controllers/CategoryController.cs
@@ -1,7 +1,5 @@
 ﻿namespace techIE.Areas.Admin.Controllers
 {
-    using System.Security.Claims;
-
     using Microsoft.AspNetCore.Mvc;
 
     using Constants;

--- a/Constants/RedirectPaths.cs
+++ b/Constants/RedirectPaths.cs
@@ -22,9 +22,9 @@
 
         // ---------- Admin Controller Redirects ----------
         public const string UpdateCategoryPage = "Categories";
-        public const string UpdateCategoryController = "Admin";
+        public const string UpdateCategoryController = "Panel";
 
         public const string UpdateProductPage = "Products";
-        public const string UpdateProductController = "Admin";
+        public const string UpdateProductController = "Panel";
     }
 }


### PR DESCRIPTION
The new names of the controller made the previous redirect paths incorrect. This has been fixed.
Also, I noticed that the CategoryController had an unused namespace, which I removed. There are probably unused namespaces in the other admin area controllers as well.