### PR TITLE
Link details page in product overviews

### DIFF
--- a/Areas/Marketplace/Views/Store/Explore.cshtml
+++ b/Areas/Marketplace/Views/Store/Explore.cshtml
@@ -104,12 +104,14 @@
     {
         @foreach (var product in Model.Products)
         {
-            <div class="product grow">
-                <img src="@product.ImageUrl">
-                <hr class="img-seperator marketplace" />
-                <h4 class="text-center">@product.Name</h4>
-                <h6 class="text-center">$@product.Price</h6>
-            </div>
+            <a class="product-details" asp-area="Marketplace" asp-controller="Product" asp-action="Details" asp-route-id="@product.Id">
+                <div class="product grow">
+                    <img src="@product.ImageUrl">
+                    <hr class="img-seperator marketplace" />
+                    <h4 class="text-center">@product.Name</h4>
+                    <h6 class="text-center">$@product.Price</h6>
+                </div>
+            </a>
         }
     }
     else

--- a/Areas/Marketplace/Views/Store/Index.cshtml
+++ b/Areas/Marketplace/Views/Store/Index.cshtml
@@ -24,12 +24,14 @@
     {
         @foreach (var product in Model)
         {
-            <div class="product grow">
-                <img src="@product.ImageUrl">
-                <hr class="img-seperator marketplace" />
-                <h4 class="text-center">@product.Name</h4>
-                <h6 class="text-center">$@product.Price</h6>
-            </div>
+            <a class="product-details" asp-area="Marketplace" asp-controller="Product" asp-action="Details" asp-route-id="@product.Id">
+                <div class="product grow">
+                    <img src="@product.ImageUrl">
+                    <hr class="img-seperator marketplace" />
+                    <h4 class="text-center">@product.Name</h4>
+                    <h6 class="text-center">$@product.Price</h6>
+                </div>
+            </a>
         }
     }
     else

--- a/Areas/Official/Views/Store/Index.cshtml
+++ b/Areas/Official/Views/Store/Index.cshtml
@@ -19,12 +19,14 @@
 <div class="product-panel">
     @foreach (var product in Model) 
     {
-        <div class="product grow">
-            <img src="@product.ImageUrl">
-            <hr class="img-seperator official" />
-            <h4 class="text-center">@product.Name</h4>
-            <h6 class="text-center">$@product.Price</h6>
-        </div>
+        <a class="product-details" asp-area="Official" asp-controller="Product" asp-action="Details" asp-route-id="@product.Id">
+            <div class="product grow">
+                <img src="@product.ImageUrl">
+                <hr class="img-seperator official" />
+                <h4 class="text-center">@product.Name</h4>
+                <h6 class="text-center">$@product.Price</h6>
+            </div>
+        </a>
     }
 </div>
 

--- a/Areas/Official/Views/Store/_OfficialProductsPartial.cshtml
+++ b/Areas/Official/Views/Store/_OfficialProductsPartial.cshtml
@@ -13,7 +13,7 @@
     {
         @if (product.Category == (string)ViewData["Product"])
         {
-            <a class="product" asp-area="Official" asp-controller="Product" asp-action="Details" asp-route-id="@product.Id">
+            <a class="product-details" asp-area="Official" asp-controller="Product" asp-action="Details" asp-route-id="@product.Id">
                 <div class="product grow">
                     <img src="@product.ImageUrl">
                     <hr class="img-seperator official" />

--- a/wwwroot/css/store/marketplace-store.css
+++ b/wwwroot/css/store/marketplace-store.css
@@ -64,3 +64,8 @@ footer .bottom-nav {
 footer .bottom-footer {
     background-color: #ffcde8;
 }
+
+a.product-details {
+    text-decoration: none!important;
+    color: black;
+}

--- a/wwwroot/css/store/official-store.css
+++ b/wwwroot/css/store/official-store.css
@@ -55,9 +55,8 @@ a {
     text-decoration: none;
 }
 
-a.product {
+a.product-details {
     color: black;
-    border: none;
 }
 
 .no-products {


### PR DESCRIPTION
Added anchors that redirect to the product detail pages where product overviews are used.
Will replace the Id in the URL of the Details pages with something else, related to the viewed product.