### PR TITLE
Add controller tests

### DIFF
--- a/techIE.UnitTests/Areas/Admin/CategoryControllerTests.cs
+++ b/techIE.UnitTests/Areas/Admin/CategoryControllerTests.cs
@@ -1,0 +1,186 @@
+﻿#nullable disable
+namespace techIE.UnitTests.Areas.Admin
+{
+    using System.Collections.Generic;
+
+    using Moq;
+    using NUnit.Framework;
+    using Microsoft.AspNetCore.Mvc;
+
+    using techIE.Contracts;
+    using techIE.Models.Categories;
+    using techIE.Models.Products;
+
+    using techIE.UnitTests.TestControllers.Areas.Admin;
+    using techIE.Data.Entities;
+
+    public class CategoryControllerTests
+    {
+        private CategoryTestController controller;
+        private Mock<ICategoryService> categoryServiceMock;
+
+        [SetUp]
+        public void Tests_Initialize()
+        {
+            categoryServiceMock = new Mock<ICategoryService>();
+
+            controller = new CategoryTestController(categoryServiceMock.Object);
+        }
+
+        [Test]
+        public void Test_AddUserIsAdmin_Valid()
+        {
+            // Arrange
+            var isUserAdmin = true;
+            
+            // Act
+            var getResult = controller.Add(isUserAdmin);
+            var postAction = controller.Add(new CategoryFormViewModel(), isUserAdmin);
+
+            // Assert
+            Assert.That(getResult, Is.TypeOf<ViewResult>());
+            Assert.That(postAction.Result, Is.TypeOf<RedirectToActionResult>());
+        }
+
+        [Test]
+        public void Test_AddUserNotAdmin_ReturnsUnauthorized()
+        {
+            // Arrange
+            var isUserAdmin = false;
+
+            // Act
+            var result = controller.Add(isUserAdmin);
+
+            // Assert
+            Assert.That(result, Is.TypeOf<UnauthorizedResult>());
+        }
+
+        [Test]
+        public void Test_EditUserIsAdmin_Valid()
+        {
+            // Arrange
+            var isUserAdmin = true;
+
+            categoryServiceMock
+                .Setup(c => c.GetAsync(It.IsAny<int>()))
+                .ReturnsAsync(new Category());
+
+            // Act
+            var getAction = controller.Edit(It.IsAny<int>(), isUserAdmin);
+            var postAction = controller.Edit(It.IsAny<CategoryFormViewModel>(), isUserAdmin);
+
+            // Assert
+            Assert.That(getAction.Result, Is.TypeOf<ViewResult>());
+            Assert.That(postAction.Result, Is.TypeOf<RedirectToActionResult>());
+        }
+
+        [Test]
+        public void Test_EditUserNotAdmin_ReturnsUnauthorized()
+        {
+            // Arrange
+            var isUserAdmin = false;
+
+            // Act
+            var action = controller.Edit(It.IsAny<int>(), isUserAdmin);
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<UnauthorizedResult>());
+        }
+
+        [Test]
+        public void Test_EditCategoryEntityNull_ReturnsNotFound()
+        {
+            // Arrange
+            var isUserAdmin = true;
+            Category category = null;
+
+            categoryServiceMock
+                .Setup(c => c.GetAsync(It.IsAny<int>()))
+                .ReturnsAsync(category);
+
+            // Act
+            var action = controller.Edit(It.IsAny<int>(), isUserAdmin);
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<NotFoundResult>());
+        }
+
+        [Test]
+        public void Test_VerifyUserIsAdmin_ReturnsRedirectToAction()
+        {
+            // Arrange
+            var isUserAdmin = true;
+
+            // Act
+            var action = controller.Verify(It.IsAny<int>(), isUserAdmin);
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<RedirectToActionResult>());
+        }
+
+        [Test]
+        public void Test_VerifyUserNotAdmin_ReturnsUnathorized()
+        {
+            // Arrange
+            var isUserAdmin = false;
+
+            // Act
+            var action = controller.Verify(It.IsAny<int>(), isUserAdmin);
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<UnauthorizedResult>());
+        }
+
+        [Test]
+        public void Test_DeleteUserIsAdmin_ReturnsRedirectToAction()
+        {
+            // Arrange
+            var isUserAdmin = true;
+
+            // Act
+            var action = controller.Delete(It.IsAny<int>(), isUserAdmin);
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<RedirectToActionResult>());
+        }
+
+        [Test]
+        public void Test_DeleteUserNotAdmin_ReturnsUnathorized()
+        {
+            // Arrange
+            var isUserAdmin = false;
+
+            // Act
+            var action = controller.Delete(It.IsAny<int>(), isUserAdmin);
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<UnauthorizedResult>());
+        }
+
+        [Test]
+        public void Test_RestoreUserIsAdmin_ReturnsRedirectToAction()
+        {
+            // Arrange
+            var isUserAdmin = true;
+
+            // Act
+            var action = controller.Restore(It.IsAny<int>(), isUserAdmin);
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<RedirectToActionResult>());
+        }
+
+        [Test]
+        public void Test_RestoreUserNotAdmin_ReturnsUnathorized()
+        {
+            // Arrange
+            var isUserAdmin = false;
+
+            // Act
+            var action = controller.Restore(It.IsAny<int>(), isUserAdmin);
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<UnauthorizedResult>());
+        }
+    }
+}

--- a/techIE.UnitTests/Areas/Admin/PanelControllerTests.cs
+++ b/techIE.UnitTests/Areas/Admin/PanelControllerTests.cs
@@ -1,0 +1,121 @@
+﻿#nullable disable
+namespace techIE.UnitTests.Areas.Admin
+{
+    using System.Collections.Generic;
+
+    using Moq;
+    using NUnit.Framework;
+    using Microsoft.AspNetCore.Mvc;
+
+    using techIE.Contracts;
+    using techIE.Models.Categories;
+    using techIE.Models.Products;
+
+    using techIE.UnitTests.TestControllers.Areas.Admin;
+
+    public class PanelControllerTests
+    {
+        private PanelTestController controller;
+        private Mock<ICategoryService> categoryServiceMock;
+        private Mock<IProductService> productServiceMock;
+
+        [SetUp]
+        public void Tests_Initialize()
+        {
+            categoryServiceMock = new Mock<ICategoryService>();
+            productServiceMock = new Mock<IProductService>();
+
+            controller = new PanelTestController(
+                categoryServiceMock.Object,
+                productServiceMock.Object);
+        }
+
+        [Test]
+        public void Test_PagesWithAdminCheckOnly_Valid_ReturnView()
+        {
+            // Arrange
+            var isUserAdmin = true;
+
+            productServiceMock
+                .Setup(p => p.GetAllAdminAsync())
+                .ReturnsAsync(new List<ProductAdminPanelViewModel>());
+
+            // Act
+            var indexAction = controller.Index(isUserAdmin);
+            var categoriesAction = controller.Categories(isUserAdmin);
+            var productsAction = controller.Products(isUserAdmin);
+
+            // Assert
+            Assert.That(indexAction, Is.TypeOf<ViewResult>());
+            Assert.That(categoriesAction.Result, Is.TypeOf<ViewResult>());
+            Assert.That(productsAction.Result, Is.TypeOf<ViewResult>());
+        }
+
+        [Test]
+        public void Test_PagesWithAdminCheckOnly_UserNotAdmin_ReturnUnauthorized()
+        {
+            // Arrange
+            var isUserAdmin = false;
+
+            // Act
+            var indexAction = controller.Index(isUserAdmin);
+            var categoriesAction = controller.Categories(isUserAdmin);
+            var productsAction = controller.Products(isUserAdmin);
+
+            // Assert
+            Assert.That(indexAction, Is.TypeOf<UnauthorizedResult>());
+            Assert.That(categoriesAction.Result, Is.TypeOf<UnauthorizedResult>());
+            Assert.That(productsAction.Result, Is.TypeOf<UnauthorizedResult>());
+        }
+
+        [Test]
+        public void Test_EmptyCategoryList_Valid_ReturnsView()
+        {
+            // Arrange
+            var isUserAdmin = true;
+
+            categoryServiceMock
+                .Setup(c => c.GetOfficialAsync())
+                .ReturnsAsync(new List<CategoryViewModel>());
+
+            // Act
+            var action = controller.Empty(isUserAdmin);
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<ViewResult>());
+        }
+
+        [Test]
+        public void Test_EmptyCategoryList_UserNotAdmin_ReturnsUnauthorized()
+        {
+            // Arrange
+            var isUserAdmin = false;
+
+            // Act
+            var action = controller.Empty(isUserAdmin);
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<UnauthorizedResult>());
+        }
+
+        [Test]
+        public void Test_EmptyCategoryList_WithCategories_ReturnsBadRequest()
+        {
+            // Arrange
+            var isUserAdmin = true;
+            var categories = new List<CategoryViewModel>();
+            var category = new CategoryViewModel();
+
+            categories.Add(category);
+            categoryServiceMock
+                .Setup(c => c.GetOfficialAsync())
+                .ReturnsAsync(categories);
+
+            // Act
+            var action = controller.Empty(isUserAdmin);
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<BadRequestResult>());
+        }
+    }
+}

--- a/techIE.UnitTests/Areas/Admin/ProductControllerTests.cs
+++ b/techIE.UnitTests/Areas/Admin/ProductControllerTests.cs
@@ -9,7 +9,6 @@ namespace techIE.UnitTests.Areas.Admin
 
     using techIE.Contracts;
     using techIE.Models.Categories;
-    using techIE.Models;
     using techIE.Models.Products;
 
     using techIE.UnitTests.TestControllers.Areas.Admin;

--- a/techIE.UnitTests/Areas/Admin/ProductControllerTests.cs
+++ b/techIE.UnitTests/Areas/Admin/ProductControllerTests.cs
@@ -1,0 +1,216 @@
+﻿#nullable disable
+namespace techIE.UnitTests.Areas.Admin
+{
+    using System.Collections.Generic;
+
+    using Moq;
+    using NUnit.Framework;
+    using Microsoft.AspNetCore.Mvc;
+
+    using techIE.Contracts;
+    using techIE.Models.Categories;
+    using techIE.Models;
+    using techIE.Models.Products;
+
+    using techIE.UnitTests.TestControllers.Areas.Admin;
+
+    public class ProductControllerTests
+    {
+        private ProductTestController controller;
+        private Mock<IProductService> productServiceMock;
+        private Mock<ICategoryService> categoryServiceMock;
+
+        [SetUp]
+        public void Tests_Initialize()
+        {
+            productServiceMock = new Mock<IProductService>();
+            categoryServiceMock = new Mock<ICategoryService>();
+
+            controller = new ProductTestController(
+                productServiceMock.Object,
+                categoryServiceMock.Object);
+        }
+
+        [Test]
+        public void Test_AddValid_ReturnsView()
+        {
+            // Arrange
+            var isUserAdmin = true;
+            var categories = new List<CategoryViewModel>();
+            var category = new CategoryViewModel() { IsOfficial = true };
+
+            categories.Add(category);
+            categoryServiceMock
+                .Setup(c => c.GetOfficialAsync())
+                .ReturnsAsync(categories);
+
+            // Act
+            var getAction = controller.Add(isUserAdmin);
+            var postAction = controller.Add(new ProductFormViewModel(), isUserAdmin);
+
+            // Assert
+            Assert.That(getAction.Result, Is.TypeOf<ViewResult>());
+            Assert.That(postAction.Result, Is.TypeOf<RedirectToActionResult>());
+        }
+
+        [Test]
+        public void Test_AddUserNotAdmin_ReturnsUnauthorized()
+        {
+            // Arrange
+            var isUserAdmin = false;
+
+            // Act
+            var action = controller.Add(isUserAdmin);
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<UnauthorizedResult>());
+        }
+
+        [Test]
+        public void Test_AddNoCategoriesAvailable_ReturnsRedirectToAction()
+        {
+            // Arrange
+            var isUserAdmin = true;
+
+            categoryServiceMock
+                .Setup(c => c.GetOfficialAsync())
+                .ReturnsAsync(new List<CategoryViewModel>());
+
+            // Act
+            var action = controller.Add(isUserAdmin);
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<RedirectToActionResult>());
+        }
+
+        [Test]
+        public void Test_EditValid_ReturnsView()
+        {
+            // Arrange
+            var isUserAdmin = true;
+            var model = new ProductFormViewModel();
+            var categories = new List<CategoryViewModel>();
+            var category = new CategoryViewModel() { IsOfficial = true };
+
+            categories.Add(category);
+            categoryServiceMock
+                .Setup(c => c.GetOfficialAsync())
+                .ReturnsAsync(categories);
+
+            productServiceMock
+                .Setup(p => p.GetFormModelAsync(It.IsAny<int>()))
+                .ReturnsAsync(model);
+
+            // Act
+            var action = controller.Edit(It.IsAny<int>(), isUserAdmin);
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<ViewResult>());
+        }
+
+        [Test]
+        public void Test_EditUserNotAdmin_ReturnsUnauthorized()
+        {
+            // Arrange
+            var isUserAdmin = false;
+
+            // Act
+            var action = controller.Edit(It.IsAny<int>(), isUserAdmin);
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<UnauthorizedResult>());
+        }
+
+        [Test]
+        public void Test_EditNullProductModel_ReturnsNotFound()
+        {
+            // Arrange
+            var isUserAdmin = true;
+            ProductFormViewModel model = null;
+
+            productServiceMock
+                .Setup(p => p.GetFormModelAsync(It.IsAny<int>()))
+                .ReturnsAsync(model);
+
+            // Act
+            var action = controller.Edit(It.IsAny<int>(), isUserAdmin);
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<NotFoundResult>());
+        }
+
+        [Test]
+        public void Test_EditNoCategoriesAvailable_ReturnsRedirectToAction()
+        {
+            // Arrange
+            var isUserAdmin = true;
+            var model = new ProductFormViewModel();
+
+            categoryServiceMock
+                .Setup(c => c.GetOfficialAsync())
+                .ReturnsAsync(new List<CategoryViewModel>());
+
+            productServiceMock
+                .Setup(p => p.GetFormModelAsync(It.IsAny<int>()))
+                .ReturnsAsync(model);
+
+            // Act
+            var action = controller.Edit(It.IsAny<int>(), isUserAdmin);
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<RedirectToActionResult>());
+        }
+
+        [Test]
+        public void Test_DeleteUserIsAdmin_ReturnsRedirectToAction()
+        {
+            // Arrange
+            var isUserAdmin = true;
+
+            // Act
+            var action = controller.Delete(It.IsAny<int>(), isUserAdmin);
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<RedirectToActionResult>());
+        }
+
+        [Test]
+        public void Test_DeleteUserNotAdmin_ReturnsUnauthorized()
+        {
+            // Arrange
+            var isUserAdmin = false;
+
+            // Act
+            var action = controller.Delete(It.IsAny<int>(), isUserAdmin);
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<UnauthorizedResult>());
+        }
+
+        [Test]
+        public void Test_RestoreUserIsAdmin_ReturnsRedirectToAction()
+        {
+            // Arrange
+            var isUserAdmin = true;
+
+            // Act
+            var action = controller.Restore(It.IsAny<int>(), isUserAdmin);
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<RedirectToActionResult>());
+        }
+
+        [Test]
+        public void Test_RestoreUserNotAdmin_ReturnsUnauthorized()
+        {
+            // Arrange
+            var isUserAdmin = false;
+
+            // Act
+            var action = controller.Restore(It.IsAny<int>(), isUserAdmin);
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<UnauthorizedResult>());
+        }
+    }
+}

--- a/techIE.UnitTests/Areas/Marketplace/ProductControllerTests.cs
+++ b/techIE.UnitTests/Areas/Marketplace/ProductControllerTests.cs
@@ -1,14 +1,11 @@
 ﻿namespace techIE.UnitTests.Areas.Marketplace
 {
-    using System.Threading.Tasks;
     using System.Collections.Generic;
 
     using Moq;
     using NUnit.Framework;
     using Microsoft.AspNetCore.Mvc;
 
-    using techIE.Controllers;
-    using techIE.Constants;
     using techIE.Contracts;
     using techIE.Areas.Marketplace.Controllers;
     using techIE.Models.Categories;

--- a/techIE.UnitTests/Areas/Marketplace/ProductControllerTests.cs
+++ b/techIE.UnitTests/Areas/Marketplace/ProductControllerTests.cs
@@ -1,4 +1,5 @@
-﻿namespace techIE.UnitTests.Areas.Marketplace
+﻿#nullable disable
+namespace techIE.UnitTests.Areas.Marketplace
 {
     using System.Collections.Generic;
 
@@ -7,10 +8,11 @@
     using Microsoft.AspNetCore.Mvc;
 
     using techIE.Contracts;
-    using techIE.Areas.Marketplace.Controllers;
     using techIE.Models.Categories;
     using techIE.Models;
     using techIE.Models.Products;
+
+    using techIE.UnitTests.TestControllers.Areas.Marketplace;
 
     public class ProductControllerTests
     {

--- a/techIE.UnitTests/Areas/Marketplace/ProductControllerTests.cs
+++ b/techIE.UnitTests/Areas/Marketplace/ProductControllerTests.cs
@@ -1,0 +1,318 @@
+﻿namespace techIE.UnitTests.Areas.Marketplace
+{
+    using System.Threading.Tasks;
+    using System.Collections.Generic;
+
+    using Moq;
+    using NUnit.Framework;
+    using Microsoft.AspNetCore.Mvc;
+
+    using techIE.Controllers;
+    using techIE.Constants;
+    using techIE.Contracts;
+    using techIE.Areas.Marketplace.Controllers;
+    using techIE.Models.Categories;
+    using techIE.Models;
+    using techIE.Models.Products;
+
+    public class ProductControllerTests
+    {
+        private ProductTestController controller;
+        private Mock<IUserService> userServiceMock;
+        private Mock<IProductService> productServiceMock;
+        private Mock<ICategoryService> categoryServiceMock;
+
+        [SetUp]
+        public void Tests_Initialize()
+        {
+            userServiceMock = new Mock<IUserService>();
+            productServiceMock = new Mock<IProductService>();
+            categoryServiceMock = new Mock<ICategoryService>();
+
+            controller = new ProductTestController(
+                userServiceMock.Object,
+                productServiceMock.Object,
+                categoryServiceMock.Object);
+        }
+
+        [Test]
+        public void Test_AddProductToMarketplace_WithCategories()
+        {
+            // Arrange
+            var categories = new List<CategoryViewModel>();
+            var category = new CategoryViewModel();
+            
+            categories.Add(category);
+            categoryServiceMock
+                .Setup(c => c.GetAllAvailableAsync())
+                .ReturnsAsync(categories);
+
+            // Act
+            var getAction = controller.Add();
+            var postAction = controller.Add(new ProductFormViewModel());
+
+            // Assert
+            Assert.That(getAction.Result, Is.TypeOf<ViewResult>());
+            Assert.That(postAction.Result, Is.TypeOf<RedirectToActionResult>());
+        }
+
+        [Test]
+        public void Test_AddProductToMarketplace_WithoutCategories()
+        {
+            // Arrange
+            var categories = new List<CategoryViewModel>();
+
+            categoryServiceMock
+                .Setup(c => c.GetAllAvailableAsync())
+                .ReturnsAsync(categories);
+
+            // Act
+            var action = controller.Add();
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<RedirectToActionResult>());
+        }
+
+        [Test]
+        public void Test_ViewProductDetails_ReturnsView()
+        {
+            // Arrange
+            userServiceMock
+                .Setup(u => u.GetUserByProductIdAsync(It.IsAny<int>()))
+                .ReturnsAsync(new UserViewModel());
+
+            productServiceMock
+                .Setup(p => p.GetDetailedAsync(It.IsAny<int>(), It.IsAny<UserViewModel>()))
+                .ReturnsAsync(new ProductDetailedViewModel() { IsOfficial = false });
+
+            // Act
+            var action = controller.Details(It.IsAny<int>());
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<ViewResult>());
+        }
+
+        [Test]
+        public void Test_ViewProductDetails_NoSeller_ReturnsBadRequest()
+        {
+            // Arrange
+            UserViewModel seller = null;
+            userServiceMock
+                .Setup(u => u.GetUserByProductIdAsync(It.IsAny<int>()))
+                .ReturnsAsync(seller);
+
+            // Act
+            var action = controller.Details(It.IsAny<int>());
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<BadRequestResult>());
+        }
+
+        [Test]
+        public void Test_ViewProductDetails_NoProduct_ReturnsNotFound()
+        {
+            // Arrange
+            userServiceMock
+                .Setup(u => u.GetUserByProductIdAsync(It.IsAny<int>()))
+                .ReturnsAsync(new UserViewModel());
+
+            ProductDetailedViewModel model = null;
+            productServiceMock
+                .Setup(p => p.GetDetailedAsync(It.IsAny<int>(), It.IsAny<UserViewModel>()))
+                .ReturnsAsync(model);
+
+            // Act
+            var action = controller.Details(It.IsAny<int>());
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<NotFoundResult>());
+        }
+
+        [Test]
+        public void Test_ViewProductDetails_DeletedProduct_ReturnsNotFound()
+        {
+            // Arrange
+            userServiceMock
+                .Setup(u => u.GetUserByProductIdAsync(It.IsAny<int>()))
+                .ReturnsAsync(new UserViewModel());
+
+            productServiceMock
+                .Setup(p => p.GetDetailedAsync(It.IsAny<int>(), It.IsAny<UserViewModel>()))
+                .ReturnsAsync(new ProductDetailedViewModel() { IsDeleted = true });
+
+            // Act
+            var action = controller.Details(It.IsAny<int>());
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<NotFoundResult>());
+        }
+
+        [Test]
+        public void Test_ViewProductDetails_IsOfficial_ReturnsRedirectToAction()
+        {
+            // Arrange
+            userServiceMock
+                .Setup(u => u.GetUserByProductIdAsync(It.IsAny<int>()))
+                .ReturnsAsync(new UserViewModel());
+
+            productServiceMock
+                .Setup(p => p.GetDetailedAsync(It.IsAny<int>(), It.IsAny<UserViewModel>()))
+                .ReturnsAsync(new ProductDetailedViewModel() { IsOfficial = true });
+
+            // Act
+            var action = controller.Details(It.IsAny<int>());
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<RedirectToActionResult>());
+        }
+
+        [Test]
+        public void Test_EditProductDetails_ValidDetails()
+        {
+            // Arrange
+            var categories = new List<CategoryViewModel>();
+            var category = new CategoryViewModel();
+
+            categories.Add(category);
+            categoryServiceMock
+                .Setup(c => c.GetAllAvailableAsync())
+                .ReturnsAsync(categories);
+
+            productServiceMock
+                .Setup(p => p.IsUserSellerAsync(It.IsAny<int>(), It.IsAny<string>()))
+                .ReturnsAsync(true);
+
+            productServiceMock
+                .Setup(p => p.GetFormModelAsync(It.IsAny<int>()))
+                .ReturnsAsync(new ProductFormViewModel());
+
+            // Act
+            var getAction = controller.Edit(It.IsAny<int>());
+            var postAction = controller.Edit(It.IsAny<ProductFormViewModel>());
+
+            // Assert
+            Assert.That(getAction.Result, Is.TypeOf<ViewResult>());
+            Assert.That(postAction.Result, Is.TypeOf<RedirectToActionResult>());
+        }
+
+        [Test]
+        public void Test_EditProductDetails_InvalidUser()
+        {
+            // Arrange
+            productServiceMock
+                .Setup(p => p.IsUserSellerAsync(It.IsAny<int>(), It.IsAny<string>()))
+                .ReturnsAsync(false);
+
+            // Act
+            var action = controller.Edit(It.IsAny<int>());
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<NotFoundResult>());
+        }
+
+        [Test]
+        public void Test_EditProductDetails_NullModel()
+        {
+            // Arrange
+            ProductFormViewModel model = null;
+            productServiceMock
+                .Setup(p => p.IsUserSellerAsync(It.IsAny<int>(), It.IsAny<string>()))
+                .ReturnsAsync(true);
+
+            productServiceMock
+                .Setup(p => p.GetFormModelAsync(It.IsAny<int>()))
+                .ReturnsAsync(model);
+
+            // Act
+            var action = controller.Edit(It.IsAny<int>());
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<NotFoundResult>());
+        }
+
+        [Test]
+        public void Test_EditProductDetails_WithoutCategories()
+        {
+            // Arrange
+            var categories = new List<CategoryViewModel>();
+
+            categoryServiceMock
+                .Setup(c => c.GetAllAvailableAsync())
+                .ReturnsAsync(categories);
+
+            productServiceMock
+                .Setup(p => p.IsUserSellerAsync(It.IsAny<int>(), It.IsAny<string>()))
+                .ReturnsAsync(true);
+
+            productServiceMock
+                .Setup(p => p.GetFormModelAsync(It.IsAny<int>()))
+                .ReturnsAsync(new ProductFormViewModel());
+
+            // Act
+            var action = controller.Edit(It.IsAny<int>());
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<RedirectToActionResult>());
+        }
+
+        [Test]
+        public void Test_DeleteProduct_WithCurrentUser()
+        {
+            // Arrange
+            productServiceMock
+                .Setup(p => p.IsUserSellerAsync(It.IsAny<int>(), It.IsAny<string>()))
+                .ReturnsAsync(true);
+
+            // Act
+            var action = controller.Delete(It.IsAny<int>());
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<RedirectToActionResult>());
+        }
+
+        [Test]
+        public void Test_DeleteProduct_WithInvalidUser()
+        {
+            // Arrange
+            productServiceMock
+                .Setup(p => p.IsUserSellerAsync(It.IsAny<int>(), It.IsAny<string>()))
+                .ReturnsAsync(false);
+
+            // Act
+            var action = controller.Delete(It.IsAny<int>());
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<NotFoundResult>());
+        }
+
+        [Test]
+        public void Test_RestoreProduct_WithCurrentUser()
+        {
+            // Arrange
+            productServiceMock
+                .Setup(p => p.IsUserSellerAsync(It.IsAny<int>(), It.IsAny<string>()))
+                .ReturnsAsync(true);
+
+            // Act
+            var action = controller.Restore(It.IsAny<int>());
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<RedirectToActionResult>());
+        }
+
+        [Test]
+        public void Test_RestoreProduct_WithInvalidUser()
+        {
+            // Arrange
+            productServiceMock
+                .Setup(p => p.IsUserSellerAsync(It.IsAny<int>(), It.IsAny<string>()))
+                .ReturnsAsync(false);
+
+            // Act
+            var action = controller.Restore(It.IsAny<int>());
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<NotFoundResult>());
+        }
+    }
+}

--- a/techIE.UnitTests/Areas/Marketplace/StoreControllerTests.cs
+++ b/techIE.UnitTests/Areas/Marketplace/StoreControllerTests.cs
@@ -1,4 +1,5 @@
-﻿namespace techIE.UnitTests.Areas.Marketplace
+﻿#nullable disable
+namespace techIE.UnitTests.Areas.Marketplace
 {
     using System.Collections.Generic;
 

--- a/techIE.UnitTests/Areas/Marketplace/StoreControllerTests.cs
+++ b/techIE.UnitTests/Areas/Marketplace/StoreControllerTests.cs
@@ -1,0 +1,84 @@
+﻿namespace techIE.UnitTests.Areas.Marketplace
+{
+    using System.Collections.Generic;
+
+    using Microsoft.AspNetCore.Mvc;
+
+    using Moq;
+    using NUnit.Framework;
+
+    using Contracts;
+    using techIE.Models.Products;
+    using techIE.Areas.Marketplace.Controllers;
+
+    using techIE.Models.Categories;
+
+    public class StoreControllerTests
+    {
+        private StoreController controller;
+        private Mock<IProductService> productServiceMock;
+        private Mock<ICategoryService> categoryServiceMock;
+
+        [SetUp]
+        public void Tests_Initialize()
+        {
+            productServiceMock = new Mock<IProductService>();
+            categoryServiceMock = new Mock<ICategoryService>();
+
+            controller = new StoreController(
+                productServiceMock.Object,
+                categoryServiceMock.Object);
+        }
+
+        [Test]
+        public void Test_Index_AlwaysReturnsView()
+        {
+            // Arrange
+            productServiceMock
+                .Setup(p => p.GetThreeRandomAsync(It.IsAny<bool>()))
+                .ReturnsAsync(new List<ProductOverviewViewModel>());
+
+            // Act
+            var action = controller.Index();
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<ViewResult>());
+        }
+
+        [Test]
+        public void Test_Empty_WithCategories()
+        {
+            // Arrange
+            var categories = new List<CategoryViewModel>();
+            var category = new CategoryViewModel();
+
+            categories.Add(category);
+            categoryServiceMock
+                .Setup(c => c.GetAllAvailableAsync())
+                .ReturnsAsync(categories);
+
+            // Act
+            var action = controller.Empty();
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<BadRequestResult>());
+        }
+
+        [Test]
+        public void Test_Empty_WithoutCategories()
+        {
+            // Arrange
+            var categories = new List<CategoryViewModel>();
+
+            categoryServiceMock
+                .Setup(c => c.GetAllAvailableAsync())
+                .ReturnsAsync(categories);
+
+            // Act
+            var action = controller.Empty();
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<ViewResult>());
+        }
+    }
+}

--- a/techIE.UnitTests/Areas/Official/ProductControllerTests.cs
+++ b/techIE.UnitTests/Areas/Official/ProductControllerTests.cs
@@ -1,0 +1,124 @@
+﻿namespace techIE.UnitTests.Areas.Official
+{
+    using System.Collections.Generic;
+
+    using Moq;
+    using NUnit.Framework;
+    using Microsoft.AspNetCore.Mvc;
+
+    using techIE.Contracts;
+    using techIE.Areas.Official.Controllers;
+    using techIE.Models.Categories;
+    using techIE.Models;
+    using techIE.Models.Products;
+
+    public class ProductControllerTests
+    {
+        private ProductController controller;
+        private Mock<IUserService> userServiceMock;
+        private Mock<IProductService> productServiceMock;
+
+        [SetUp]
+        public void Tests_Initialize()
+        {
+            userServiceMock = new Mock<IUserService>();
+            productServiceMock = new Mock<IProductService>();
+
+            controller = new ProductController(
+                userServiceMock.Object,
+                productServiceMock.Object);
+        }
+
+        [Test]
+        public void Test_DetailsValid_ReturnsView()
+        {
+            // Arrange
+            userServiceMock
+                .Setup(u => u.GetUserByProductIdAsync(It.IsAny<int>()))
+                .ReturnsAsync(new UserViewModel());
+
+            productServiceMock
+                .Setup(p => p.GetDetailedAsync(It.IsAny<int>(), It.IsAny<UserViewModel>()))
+                .ReturnsAsync(new ProductDetailedViewModel() { IsOfficial = true });
+
+            // Act
+            var action = controller.Details(It.IsAny<int>());
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<ViewResult>());
+        }
+
+        [Test]
+        public void Test_DetailsNoSeller_ReturnsBadRequest()
+        {
+            // Arrange
+            UserViewModel seller = null;
+            userServiceMock
+                .Setup(u => u.GetUserByProductIdAsync(It.IsAny<int>()))
+                .ReturnsAsync(seller);
+            // Act
+            var action = controller.Details(It.IsAny<int>());
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<BadRequestResult>());
+        }
+
+        [Test]
+        public void Test_DetailsNoModel_ReturnsNotFound()
+        {
+            // Arrange
+            ProductDetailedViewModel model = null;
+            userServiceMock
+                .Setup(u => u.GetUserByProductIdAsync(It.IsAny<int>()))
+                .ReturnsAsync(new UserViewModel());
+
+            productServiceMock
+                .Setup(p => p.GetDetailedAsync(It.IsAny<int>(), It.IsAny<UserViewModel>()))
+                .ReturnsAsync(model);
+
+            // Act
+            var action = controller.Details(It.IsAny<int>());
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<NotFoundResult>());
+        }
+
+        [Test]
+        public void Test_DetailsDeletedModel_ReturnsNotFound()
+        {
+            // Arrange
+            userServiceMock
+                .Setup(u => u.GetUserByProductIdAsync(It.IsAny<int>()))
+                .ReturnsAsync(new UserViewModel());
+
+            productServiceMock
+                .Setup(p => p.GetDetailedAsync(It.IsAny<int>(), It.IsAny<UserViewModel>()))
+                .ReturnsAsync(new ProductDetailedViewModel() { IsDeleted = true });
+
+            // Act
+            var action = controller.Details(It.IsAny<int>());
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<NotFoundResult>());
+        }
+
+        [Test]
+        public void Test_DetailsMarketplaceProduct_ReturmsRedirectToAction()
+        {
+            // Arrange
+            userServiceMock
+                .Setup(u => u.GetUserByProductIdAsync(It.IsAny<int>()))
+                .ReturnsAsync(new UserViewModel());
+
+            productServiceMock
+                .Setup(p => p.GetDetailedAsync(It.IsAny<int>(), It.IsAny<UserViewModel>()))
+                .ReturnsAsync(new ProductDetailedViewModel() { IsOfficial = false });
+
+            // Act
+            var action = controller.Details(It.IsAny<int>());
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<RedirectToActionResult>());
+        }
+    }
+}

--- a/techIE.UnitTests/Areas/Official/ProductControllerTests.cs
+++ b/techIE.UnitTests/Areas/Official/ProductControllerTests.cs
@@ -1,14 +1,11 @@
 ﻿namespace techIE.UnitTests.Areas.Official
 {
-    using System.Collections.Generic;
-
     using Moq;
     using NUnit.Framework;
     using Microsoft.AspNetCore.Mvc;
 
     using techIE.Contracts;
     using techIE.Areas.Official.Controllers;
-    using techIE.Models.Categories;
     using techIE.Models;
     using techIE.Models.Products;
 

--- a/techIE.UnitTests/Areas/Official/ProductControllerTests.cs
+++ b/techIE.UnitTests/Areas/Official/ProductControllerTests.cs
@@ -1,4 +1,5 @@
-﻿namespace techIE.UnitTests.Areas.Official
+﻿#nullable disable
+namespace techIE.UnitTests.Areas.Official
 {
     using Moq;
     using NUnit.Framework;

--- a/techIE.UnitTests/Areas/Official/StoreControllerTests.cs
+++ b/techIE.UnitTests/Areas/Official/StoreControllerTests.cs
@@ -1,4 +1,5 @@
-﻿namespace techIE.UnitTests.Areas.Official
+﻿#nullable disable
+namespace techIE.UnitTests.Areas.Official
 {
     using Microsoft.AspNetCore.Mvc;
 

--- a/techIE.UnitTests/Areas/Official/StoreControllerTests.cs
+++ b/techIE.UnitTests/Areas/Official/StoreControllerTests.cs
@@ -1,0 +1,42 @@
+﻿namespace techIE.UnitTests.Areas.Official
+{
+    using Microsoft.AspNetCore.Mvc;
+
+    using Moq;
+    using NUnit.Framework;
+
+    using Contracts;
+    using techIE.Areas.Official.Controllers;
+
+    public class StoreControllerTests
+    {
+        private StoreController controller;
+        private Mock<IProductService> productServiceMock;
+
+        [SetUp]
+        public void Tests_Initialize()
+        {
+            productServiceMock = new Mock<IProductService>();
+
+            controller = new StoreController(productServiceMock.Object);
+        }
+
+        [Test]
+        public void Test_Pages_AlwaysReturnView()
+        {
+            // Arrange
+
+            // Act
+            var indexAction = controller.Index();
+            var phonesAction = controller.Phones();
+            var laptopAction = controller.Laptops();
+            var smartAction = controller.Smart();
+
+            // Assert
+            Assert.That(indexAction.Result, Is.TypeOf<ViewResult>());
+            Assert.That(phonesAction.Result, Is.TypeOf<ViewResult>());
+            Assert.That(laptopAction.Result, Is.TypeOf<ViewResult>());
+            Assert.That(smartAction.Result, Is.TypeOf<ViewResult>());
+        }
+    }
+}

--- a/techIE.UnitTests/Controllers/CartControllerTests.cs
+++ b/techIE.UnitTests/Controllers/CartControllerTests.cs
@@ -1,24 +1,24 @@
-﻿using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
-
-using Moq;
-using NUnit.Framework;
-
-using techIE.Constants;
-using techIE.Contracts;
-using techIE.Data.Entities.Enums;
-using techIE.Models.Carts;
-
-using techIE.UnitTests.TestControllers;
-
-namespace techIE.UnitTests.Controllers
+﻿namespace techIE.UnitTests.Controllers
 {
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.ViewFeatures;
+
+    using Moq;
+    using NUnit.Framework;
+
+    using Constants;
+    using Contracts;
+    using Models.Carts;
+    using techIE.Data.Entities.Enums;
+
+    using techIE.UnitTests.TestControllers;
+
     public class CartControllerTests
     {
         // Using a new cartController, because the static ClaimsPrincipalExtensions User.Id() method doesn't allow the tests to run.
-        private TempDataDictionary tempData;
         private CartTestController controller;
+        private TempDataDictionary tempData;
         private Mock<ICartService> cartServiceMock;
 
         [SetUp]

--- a/techIE.UnitTests/Controllers/CartControllerTests.cs
+++ b/techIE.UnitTests/Controllers/CartControllerTests.cs
@@ -171,7 +171,7 @@
             var action = controller.History(It.IsAny<int>());
 
             // Assert
-            Assert.That(action.Result, Is.TypeOf<RedirectToActionResult>());
+            Assert.That(action.Result, Is.TypeOf<ViewResult>());
         }
 
         [Test]

--- a/techIE.UnitTests/Controllers/CartControllerTests.cs
+++ b/techIE.UnitTests/Controllers/CartControllerTests.cs
@@ -1,4 +1,5 @@
-﻿namespace techIE.UnitTests.Controllers
+﻿#nullable disable
+namespace techIE.UnitTests.Controllers
 {
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;

--- a/techIE.UnitTests/Controllers/CartControllerTests.cs
+++ b/techIE.UnitTests/Controllers/CartControllerTests.cs
@@ -1,0 +1,192 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+
+using Moq;
+using NUnit.Framework;
+
+using techIE.Constants;
+using techIE.Contracts;
+using techIE.Data.Entities.Enums;
+using techIE.Models.Carts;
+
+using techIE.UnitTests.TestControllers;
+
+namespace techIE.UnitTests.Controllers
+{
+    public class CartControllerTests
+    {
+        // Using a new cartController, because the static ClaimsPrincipalExtensions User.Id() method doesn't allow the tests to run.
+        private TempDataDictionary tempData;
+        private CartTestController controller;
+        private Mock<ICartService> cartServiceMock;
+
+        [SetUp]
+        public void Tests_Initialize()
+        {
+            cartServiceMock = new Mock<ICartService>();
+
+            controller = new CartTestController(cartServiceMock.Object);
+
+            tempData = new TempDataDictionary(
+                new DefaultHttpContext(),
+                Mock.Of<ITempDataProvider>());
+        }
+
+        [Test]
+        public void Test_AddProductToCart_ReturnsSuccessful()
+        {
+            // Arrange
+            tempData["Cart"] = Messages.CartActionSuccessful;
+            controller.TempData = tempData;
+
+            cartServiceMock
+                .Setup(c => c.AddProductAsync(It.IsAny<int>(), It.IsAny<string>()))
+                .ReturnsAsync(CartAction.Successful);
+
+            // Act
+            var action = controller.Add(It.IsAny<int>(), It.IsAny<string>());
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<RedirectToActionResult>());
+        }
+
+        [Test]
+        public void Test_AddProductToCart_ReturnsDuplicate()
+        {
+            // Arrange
+            tempData["Cart"] = Messages.CartActionDuplicate;
+            controller.TempData = tempData;
+
+            cartServiceMock
+                .Setup(c => c.AddProductAsync(It.IsAny<int>(), It.IsAny<string>()))
+                .ReturnsAsync(CartAction.Duplicate);
+
+            // Act
+            var action = controller.Add(It.IsAny<int>(), It.IsAny<string>());
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<RedirectToActionResult>());
+        }
+
+        [Test]
+        public void Test_AddProductToCart_ReturnsFailed()
+        {
+            // Arrange
+            cartServiceMock
+                .Setup(c => c.AddProductAsync(It.IsAny<int>(), It.IsAny<string>()))
+                .ReturnsAsync(CartAction.Failed);
+
+            // Act
+            var action = controller.Add(It.IsAny<int>(), It.IsAny<string>());
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<BadRequestResult>());
+        }
+
+        [Test]
+        public void Test_InspectCart_AlwaysReturnsView()
+        {
+            // Arrange
+            cartServiceMock
+                .Setup(c => c.GetCurrentCartAsync(It.IsAny<string>()))
+                .ReturnsAsync(new CartViewModel());
+
+            // Act
+            var action = controller.Inspect();
+
+            // Arrange
+            Assert.That(action.Result, Is.TypeOf<ViewResult>());
+        }
+
+        [Test]
+        public void Test_RemoveProductFromCart_WithCurrentUser()
+        {
+            // Arrange
+            cartServiceMock
+                .Setup(c => c.IsCartForUserAsync(It.IsAny<int>(), It.IsAny<string>()))
+                .ReturnsAsync(true);
+
+            // Act
+            var action = controller.Remove(It.IsAny<int>(), It.IsAny<int>());
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<RedirectToActionResult>());
+        }
+
+        [Test]
+        public void Test_RemoveProductFromCart_WithIncorrectUser()
+        {
+            // Arrange
+            cartServiceMock
+                .Setup(c => c.IsCartForUserAsync(It.IsAny<int>(), It.IsAny<string>()))
+                .ReturnsAsync(false);
+
+            // Act
+            var action = controller.Remove(It.IsAny<int>(), It.IsAny<int>());
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<NotFoundResult>());
+        }
+
+        [Test]
+        public void Test_EmptyAllProductsFromCart_WithCurrentUser()
+        {
+            // Arrange
+            cartServiceMock
+                .Setup(c => c.IsCartForUserAsync(It.IsAny<int>(), It.IsAny<string>()))
+                .ReturnsAsync(true);
+
+            // Act
+            var action = controller.Empty(It.IsAny<int>());
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<RedirectToActionResult>());
+        }
+
+        [Test]
+        public void Test_EmptyAllProductsFromCart_WithIncorrectUser()
+        {
+            // Arrange
+            cartServiceMock
+                .Setup(c => c.IsCartForUserAsync(It.IsAny<int>(), It.IsAny<string>()))
+                .ReturnsAsync(false);
+
+            // Act
+            var action = controller.Empty(It.IsAny<int>());
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<NotFoundResult>());
+        }
+
+        [Test]
+        public void Test_GetCartHistory_WithCurrentUser()
+        {
+            // Arrange
+            cartServiceMock
+                .Setup(c => c.IsCartForUserAsync(It.IsAny<int>(), It.IsAny<string>()))
+                .ReturnsAsync(true);
+
+            // Act
+            var action = controller.History(It.IsAny<int>());
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<RedirectToActionResult>());
+        }
+
+        [Test]
+        public void Test_GetCartHistory_WithIncorrectUser()
+        {
+            // Arrange
+            cartServiceMock
+                .Setup(c => c.IsCartForUserAsync(It.IsAny<int>(), It.IsAny<string>()))
+                .ReturnsAsync(false);
+
+            // Act
+            var action = controller.History(It.IsAny<int>());
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<NotFoundResult>());
+        }
+    }
+}

--- a/techIE.UnitTests/Controllers/HomeControllerTests.cs
+++ b/techIE.UnitTests/Controllers/HomeControllerTests.cs
@@ -1,4 +1,5 @@
-﻿namespace techIE.UnitTests.Controllers
+﻿#nullable disable
+namespace techIE.UnitTests.Controllers
 {
     using NUnit.Framework;
     using Microsoft.AspNetCore.Mvc;
@@ -80,7 +81,6 @@
         public void Test_AnyOtherError_ViewResultName()
         {
             // Assert
-            var expectedViewName = "Error";
             var statusCode = 402;
 
             // Act

--- a/techIE.UnitTests/Controllers/HomeControllerTests.cs
+++ b/techIE.UnitTests/Controllers/HomeControllerTests.cs
@@ -1,0 +1,93 @@
+﻿namespace techIE.UnitTests.Controllers
+{
+    using NUnit.Framework;
+    using Microsoft.AspNetCore.Mvc;
+
+    using techIE.Controllers;
+
+    public class HomeControllerTests
+    {
+        private HomeController controller;
+
+        [SetUp]
+        public void Tests_Initialize()
+        {
+            controller = new HomeController();
+        }
+
+        [Test]
+        public void Test_PagesReturning_ViewResult()
+        {
+            // Assert
+
+            // Act
+            var indexResult = controller.Index();
+            var storyResult = controller.Story();
+            var missionResult = controller.Mission();
+
+            // Arrange
+            Assert.That(indexResult, Is.TypeOf<ViewResult>());
+            Assert.That(storyResult, Is.TypeOf<ViewResult>());
+            Assert.That(missionResult, Is.TypeOf<ViewResult>());
+        }
+
+        [Test]
+        public void Test_Error400_ViewResultName()
+        {
+            // Assert
+            var expectedViewName = "Error400";
+            var statusCode = 400;
+
+            // Act
+            var result = controller.Error(statusCode) as ViewResult;
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(expectedViewName, result.ViewName);
+        }
+
+        [Test]
+        public void Test_Error404_ViewResultName()
+        {
+            // Assert
+            var expectedViewName = "Error400";
+            var statusCode = 404;
+
+            // Act
+            var result = controller.Error(statusCode) as ViewResult;
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(expectedViewName, result.ViewName);
+        }
+
+        [Test]
+        public void Test_Error401_ViewResultName()
+        {
+            // Assert
+            var expectedViewName = "Error401";
+            var statusCode = 401;
+
+            // Act
+            var result = controller.Error(statusCode) as ViewResult;
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(expectedViewName, result.ViewName);
+        }
+
+        [Test]
+        public void Test_AnyOtherError_ViewResultName()
+        {
+            // Assert
+            var expectedViewName = "Error";
+            var statusCode = 402;
+
+            // Act
+            var result = controller.Error(statusCode);
+
+            // Assert
+            Assert.That(result, Is.TypeOf<ViewResult>());
+        }
+    }
+}

--- a/techIE.UnitTests/Controllers/OrderControllerTests.cs
+++ b/techIE.UnitTests/Controllers/OrderControllerTests.cs
@@ -1,0 +1,83 @@
+﻿namespace techIE.UnitTests.Controllers
+{
+    using System.Collections.Generic;
+
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.ViewFeatures;
+
+    using Moq;
+    using NUnit.Framework;
+
+    using Constants;
+    using Contracts;
+    using Models.Carts;
+    using techIE.Data.Entities.Enums;
+
+    using techIE.UnitTests.TestControllers;
+    using techIE.Models.Orders;
+
+    public class OrderControllerTests
+    {
+        // Using a new orderController, because the static ClaimsPrincipalExtensions User.Id() method doesn't allow the tests to run.
+        private OrderTestController controller;
+        Mock<ICartService> cartServiceMock;
+        Mock<IOrderService> orderServiceMock;
+
+        [SetUp]
+        public void Tests_Initialize()
+        {
+            cartServiceMock = new Mock<ICartService>();
+            orderServiceMock = new Mock<IOrderService>();
+
+            controller = new OrderTestController(
+                cartServiceMock.Object,
+                orderServiceMock.Object);
+        }
+
+        [Test]
+        public void Test_FinishOrder_WithCurrentUser()
+        {
+            // Arrange
+            cartServiceMock
+                .Setup(c => c.IsCartForUserAsync(It.IsAny<int>(), It.IsAny<string>()))
+                .ReturnsAsync(true);
+
+            // Act
+            var action = controller.Finish(It.IsAny<int>());
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<RedirectToActionResult>());
+        }
+
+        [Test]
+        public void Test_FinishOrder_WithIncorrectUser()
+        {
+            // Arrange
+            cartServiceMock
+                .Setup(c => c.IsCartForUserAsync(It.IsAny<int>(), It.IsAny<string>()))
+                .ReturnsAsync(false);
+
+            // Act
+            var action = controller.Finish(It.IsAny<int>());
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<NotFoundResult>());
+        }
+
+        [Test]
+        public void Test_GetOrderHistory_AlwaysReturnsView()
+        {
+            // Arrange
+            orderServiceMock
+                .Setup(o => o.GetHistoryAsync(It.IsAny<string>()))
+                .ReturnsAsync(new List<OrderHistoryViewModel>());
+
+            // Act
+            var action = controller.History();
+
+            // Assert
+            Assert.That(action.Result, Is.TypeOf<ViewResult>());
+        }
+    }
+}

--- a/techIE.UnitTests/Controllers/OrderControllerTests.cs
+++ b/techIE.UnitTests/Controllers/OrderControllerTests.cs
@@ -1,18 +1,14 @@
-﻿namespace techIE.UnitTests.Controllers
+﻿#nullable disable
+namespace techIE.UnitTests.Controllers
 {
     using System.Collections.Generic;
 
-    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
-    using Microsoft.AspNetCore.Mvc.ViewFeatures;
 
     using Moq;
     using NUnit.Framework;
 
-    using Constants;
     using Contracts;
-    using Models.Carts;
-    using techIE.Data.Entities.Enums;
 
     using techIE.UnitTests.TestControllers;
     using techIE.Models.Orders;

--- a/techIE.UnitTests/Data/TestDbContext.cs
+++ b/techIE.UnitTests/Data/TestDbContext.cs
@@ -10,7 +10,7 @@
 
     public class TestDbContext
     {
-        private AppDbContext context;
+        private readonly AppDbContext context;
 
         /// <summary>
         /// Create a test database for the unit tests.

--- a/techIE.UnitTests/Services/CartServiceTests.cs
+++ b/techIE.UnitTests/Services/CartServiceTests.cs
@@ -1,3 +1,4 @@
+#nullable disable
 namespace techIE.UnitTests.Services
 {
     using System.Linq;

--- a/techIE.UnitTests/Services/CategoryServiceTests.cs
+++ b/techIE.UnitTests/Services/CategoryServiceTests.cs
@@ -1,4 +1,5 @@
-﻿namespace techIE.UnitTests.Services
+﻿#nullable disable
+namespace techIE.UnitTests.Services
 {
     using System.Linq;
     using System.Threading.Tasks;

--- a/techIE.UnitTests/Services/OrderServiceTests.cs
+++ b/techIE.UnitTests/Services/OrderServiceTests.cs
@@ -1,4 +1,5 @@
-﻿namespace techIE.UnitTests.Services
+﻿#nullable disable
+namespace techIE.UnitTests.Services
 {
     using System.Linq;
     using System.Threading.Tasks;
@@ -59,7 +60,7 @@
             // Expected result is that no order with the provided cartId should be in the database.
             var order = await context.Orders.Where(o => o.CartId == cartId).ToListAsync();
 
-            Assert.AreEqual(expectedOrderCount, order.Count());
+            Assert.AreEqual(expectedOrderCount, order.Count);
         }
 
         [Test]

--- a/techIE.UnitTests/Services/ProductServiceTests.cs
+++ b/techIE.UnitTests/Services/ProductServiceTests.cs
@@ -1,4 +1,5 @@
-﻿namespace techIE.UnitTests.Services
+﻿#nullable disable
+namespace techIE.UnitTests.Services
 {
     using System.Linq;
     using System.Threading.Tasks;
@@ -315,7 +316,7 @@
             await productService.AddAsync(productModel, sellerId);
 
             var newProduct = context.Products.Last();
-            var newUserProductCount = context.UsersProducts.ToList().Count();
+            var newUserProductCount = context.UsersProducts.ToList().Count;
 
             Assert.IsNotNull(newProduct);
             Assert.AreNotEqual(initialUserProductCount, newUserProductCount);

--- a/techIE.UnitTests/Services/UserServiceTests.cs
+++ b/techIE.UnitTests/Services/UserServiceTests.cs
@@ -1,4 +1,5 @@
-﻿namespace techIE.UnitTests.Services
+﻿#nullable disable
+namespace techIE.UnitTests.Services
 {
     using System.Threading.Tasks;
 

--- a/techIE.UnitTests/TestControllers/Areas/Admin/CategoryTestController.cs
+++ b/techIE.UnitTests/TestControllers/Areas/Admin/CategoryTestController.cs
@@ -28,6 +28,10 @@
         /// <summary>
         /// Get request for adding a category.
         /// </summary>
+        /// <param name="isUserAdmin">
+        /// Temporary param for test controller.
+        /// Otherwise an error for no instance of ClaimsPrincpialExtensions.IsAdmin().
+        /// </param>
         /// <returns>Passed the necessary form model for the post request.</returns>
         [HttpGet]
 
@@ -46,6 +50,10 @@
         /// Post request for adding a category/updating existing categories.
         /// </summary>
         /// <param name="model">View model containing all of the categories and the add view model.</param>
+        /// <param name="isUserAdmin">
+        /// Temporary param for test controller.
+        /// Otherwise an error for no instance of ClaimsPrincpialExtensions.IsAdmin().
+        /// </param>
         /// <returns>The same view page on successfull category update.</returns>
         [HttpPost]
         public async Task<IActionResult> Add(CategoryFormViewModel model, bool isUserAdmin)
@@ -70,6 +78,10 @@
         /// Get request for editing a category.
         /// </summary>
         /// <param name="id">Id of the category that the user wants to edit.</param>
+        /// <param name="isUserAdmin">
+        /// Temporary param for test controller.
+        /// Otherwise an error for no instance of ClaimsPrincpialExtensions.IsAdmin().
+        /// </param>
         /// <returns>CategoryFormViewModel to post request, allowing the user to edit the name of the selected category.</returns>
         [HttpGet]
         public async Task<IActionResult> Edit(int id, bool isUserAdmin)
@@ -99,6 +111,10 @@
         /// Post request for editing a category.
         /// </summary>
         /// <param name="model">View model used to ensure that the new name covers the needed validations.</param>
+        /// <param name="isUserAdmin">
+        /// Temporary param for test controller.
+        /// Otherwise an error for no instance of ClaimsPrincpialExtensions.IsAdmin().
+        /// </param>
         /// <returns>If model is valid, user is redirected to admin category panel. Otherwise, they are prompted to edit the name again.</returns>
         [HttpPost]
         public async Task<IActionResult> Edit(CategoryFormViewModel model, bool isUserAdmin)
@@ -123,6 +139,10 @@
         /// Toggle the IsOfficial category property.
         /// </summary>
         /// <param name="id">Id of the category that should be verified.</param>
+        /// <param name="isUserAdmin">
+        /// Temporary param for test controller.
+        /// Otherwise an error for no instance of ClaimsPrincpialExtensions.IsAdmin().
+        /// </param>
         /// <returns></returns>
         public async Task<IActionResult> Verify(int id, bool isUserAdmin)
         {
@@ -146,6 +166,10 @@
         /// Delete category from list.
         /// </summary>
         /// <param name="id">Id of category that will be deleted.</param>
+        /// <param name="isUserAdmin">
+        /// Temporary param for test controller.
+        /// Otherwise an error for no instance of ClaimsPrincpialExtensions.IsAdmin().
+        /// </param>
         /// <returns>Returns to panel page if successful.</returns>
         public async Task<IActionResult> Delete(int id, bool isUserAdmin)
         {
@@ -164,6 +188,10 @@
         /// Restore category to list.
         /// </summary>
         /// <param name="id">Id of category that will be restored.</param>
+        /// <param name="isUserAdmin">
+        /// Temporary param for test controller.
+        /// Otherwise an error for no instance of ClaimsPrincpialExtensions.IsAdmin().
+        /// </param>
         /// <returns>Returns to panel page if successful.</returns>
         public async Task<IActionResult> Restore(int id, bool isUserAdmin)
         {

--- a/techIE.UnitTests/TestControllers/Areas/Admin/CategoryTestController.cs
+++ b/techIE.UnitTests/TestControllers/Areas/Admin/CategoryTestController.cs
@@ -1,0 +1,181 @@
+﻿namespace techIE.UnitTests.TestControllers.Areas.Admin
+{
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    using Microsoft.AspNetCore.Mvc;
+
+    using Contracts;
+
+    using techIE.Controllers;
+    using techIE.Models.Categories;
+    using techIE.Constants;
+
+    /// <summary>
+    /// Controller managing the actions which are available in the admin category panel.
+    /// No views pages are used here.
+    /// </summary>
+    [Area("Admin")]
+    public class CategoryTestController : BaseController
+    {
+        private readonly ICategoryService categoryService;
+
+        public CategoryTestController(ICategoryService _categoryService)
+        {
+            categoryService = _categoryService;
+        }
+
+        /// <summary>
+        /// Get request for adding a category.
+        /// </summary>
+        /// <returns>Passed the necessary form model for the post request.</returns>
+        [HttpGet]
+
+        public IActionResult Add(bool isUserAdmin)
+        {
+            if (!isUserAdmin)
+            {
+                return Unauthorized();
+            }
+
+            var model = new CategoryFormViewModel();
+            return View(model);
+        }
+
+        /// <summary>
+        /// Post request for adding a category/updating existing categories.
+        /// </summary>
+        /// <param name="model">View model containing all of the categories and the add view model.</param>
+        /// <returns>The same view page on successfull category update.</returns>
+        [HttpPost]
+        public async Task<IActionResult> Add(CategoryFormViewModel model, bool isUserAdmin)
+        {
+            if (!isUserAdmin)
+            {
+                return Unauthorized();
+            }
+
+            if (!ModelState.IsValid)
+            {
+                return View(model);
+            }
+
+            await categoryService.AddAsync(model);
+            return RedirectToAction(
+                RedirectPaths.UpdateCategoryPage,
+                RedirectPaths.UpdateCategoryController);
+        }
+
+        /// <summary>
+        /// Get request for editing a category.
+        /// </summary>
+        /// <param name="id">Id of the category that the user wants to edit.</param>
+        /// <returns>CategoryFormViewModel to post request, allowing the user to edit the name of the selected category.</returns>
+        [HttpGet]
+        public async Task<IActionResult> Edit(int id, bool isUserAdmin)
+        {
+            if (!isUserAdmin)
+            {
+                return Unauthorized();
+            }
+
+            var entity = await categoryService.GetAsync(id);
+            if (entity == null)
+            {
+                return NotFound();
+            }
+
+            var model = new CategoryFormViewModel()
+            {
+                Id = entity.Id,
+                Name = entity.Name,
+                IsOfficial = entity.IsOfficial
+            };
+
+            return View(model);
+        }
+
+        /// <summary>
+        /// Post request for editing a category.
+        /// </summary>
+        /// <param name="model">View model used to ensure that the new name covers the needed validations.</param>
+        /// <returns>If model is valid, user is redirected to admin category panel. Otherwise, they are prompted to edit the name again.</returns>
+        [HttpPost]
+        public async Task<IActionResult> Edit(CategoryFormViewModel model, bool isUserAdmin)
+        {
+            if (!isUserAdmin)
+            {
+                return Unauthorized();
+            }
+
+            if (!ModelState.IsValid)
+            {
+                return View(model);
+            }
+
+            await categoryService.EditAsync(model);
+            return RedirectToAction(
+                RedirectPaths.UpdateCategoryPage,
+                RedirectPaths.UpdateCategoryController);
+        }
+
+        /// <summary>
+        /// Toggle the IsOfficial category property.
+        /// </summary>
+        /// <param name="id">Id of the category that should be verified.</param>
+        /// <returns></returns>
+        public async Task<IActionResult> Verify(int id, bool isUserAdmin)
+        {
+            if (!isUserAdmin)
+            {
+                return Unauthorized();
+            }
+
+            if (!ModelState.IsValid)
+            {
+                return BadRequest();
+            }
+
+            await categoryService.VerifyAsync(id);
+            return RedirectToAction(
+                RedirectPaths.UpdateCategoryPage,
+                RedirectPaths.UpdateCategoryController);
+        }
+
+        /// <summary>
+        /// Delete category from list.
+        /// </summary>
+        /// <param name="id">Id of category that will be deleted.</param>
+        /// <returns>Returns to panel page if successful.</returns>
+        public async Task<IActionResult> Delete(int id, bool isUserAdmin)
+        {
+            if (!isUserAdmin)
+            {
+                return Unauthorized();
+            }
+
+            await categoryService.DeleteAsync(id);
+            return RedirectToAction(
+                RedirectPaths.UpdateCategoryPage,
+                RedirectPaths.UpdateCategoryController);
+        }
+
+        /// <summary>
+        /// Restore category to list.
+        /// </summary>
+        /// <param name="id">Id of category that will be restored.</param>
+        /// <returns>Returns to panel page if successful.</returns>
+        public async Task<IActionResult> Restore(int id, bool isUserAdmin)
+        {
+            if (!isUserAdmin)
+            {
+                return Unauthorized();
+            }
+
+            await categoryService.RestoreAsync(id);
+            return RedirectToAction(
+                RedirectPaths.UpdateCategoryPage,
+                RedirectPaths.UpdateCategoryController);
+        }
+    }
+}

--- a/techIE.UnitTests/TestControllers/Areas/Admin/PanelTestController.cs
+++ b/techIE.UnitTests/TestControllers/Areas/Admin/PanelTestController.cs
@@ -1,0 +1,118 @@
+﻿namespace techIE.UnitTests.TestControllers.Areas.Admin
+{
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    using Microsoft.AspNetCore.Mvc;
+
+    using Contracts;
+
+    using techIE.Controllers;
+
+    /// <summary>
+    /// Controller for the admin access.
+    /// Only accessible by users with the Administrator/Admin role.
+    /// </summary>
+    [Area("Admin")]
+    public class PanelTestController : BaseController
+    {
+        private readonly ICategoryService categoryService;
+        private readonly IProductService productService;
+
+        public PanelTestController(
+            ICategoryService _categoryService,
+            IProductService _productService)
+        {
+            categoryService = _categoryService;
+            productService = _productService;
+        }
+
+        /// <summary>
+        /// Index page for the Panel controller.
+        /// Admins can access all of the admin pages from here.
+        /// </summary>
+        /// <param name="isUserAdmin">
+        /// Temporary param for test controller.
+        /// Otherwise an error for no instance of ClaimsPrincpialExtensions.IsAdmin().
+        /// </param>
+        /// <returns>Panel index page.</returns>
+        [HttpGet]
+        public IActionResult Index(bool isUserAdmin)
+        {
+            if (!isUserAdmin)
+            {
+                return Unauthorized();
+            }
+
+            return View();
+        }
+
+        /// <summary>
+        /// Checks if the current user is an admin. If not, they are redirected.
+        /// If user is admin, they can manage all categories.
+        /// </summary>
+        /// <param name="isUserAdmin">
+        /// Temporary param for test controller.
+        /// Otherwise an error for no instance of ClaimsPrincpialExtensions.IsAdmin().
+        /// </param>
+        /// <returns>Category panel page.</returns>
+        [HttpGet]
+        public async Task<IActionResult> Categories(bool isUserAdmin)
+        {
+            if (!isUserAdmin)
+            {
+                return Unauthorized();
+            }
+
+            var model = await categoryService.GetAllAsync();
+            return View(model);
+        }
+
+        /// <summary>
+        /// Checks if the current user is an admin. If not, they are redirected.
+        /// If user is admin, they can manage all official products.
+        /// </summary>
+        /// <param name="isUserAdmin">
+        /// Temporary param for test controller.
+        /// Otherwise an error for no instance of ClaimsPrincpialExtensions.IsAdmin().
+        /// </param>
+        /// <returns>Product panel page.</returns>
+        [HttpGet]
+        public async Task<IActionResult> Products(bool isUserAdmin)
+        {
+            if (!isUserAdmin)
+            {
+                return Unauthorized();
+            }
+
+            var model = await productService.GetAllAdminAsync();
+            return View(model);
+        }
+
+        /// <summary>
+        /// Checks if the current user is an admin. If not, they are redirected.
+        /// If user tries to add/edit an official product and no category has IsDeleted == false, they get redirected here.
+        /// </summary>
+        /// <param name="isUserAdmin">
+        /// Temporary param for test controller.
+        /// Otherwise an error for no instance of ClaimsPrincpialExtensions.IsAdmin().
+        /// </param>
+        /// <returns>Page, informing the admin that no official categories are available.</returns>
+        [HttpGet]
+        public async Task<IActionResult> Empty(bool isUserAdmin)
+        {
+            if (!isUserAdmin)
+            {
+                return Unauthorized();
+            }
+
+            var officialCategories = await categoryService.GetOfficialAsync();
+            if (officialCategories.Any())
+            {
+                return BadRequest();
+            }
+
+            return View();
+        }
+    }
+}

--- a/techIE.UnitTests/TestControllers/Areas/Admin/ProductTestController.cs
+++ b/techIE.UnitTests/TestControllers/Areas/Admin/ProductTestController.cs
@@ -35,6 +35,10 @@
         /// Get request for adding a product from the admin product panel.
         /// Can't be accessed by users that aren't admins.
         /// </summary>
+        /// <param name="isUserAdmin">
+        /// Temporary param for test controller.
+        /// Otherwise an error for no instance of CLaimsPrincpialExtensions.IsAdmin().
+        /// </param>
         /// <returns>Model to add to post request.</returns>
         [HttpGet]
         public async Task<IActionResult> Add(bool isUserAdmin)
@@ -64,6 +68,10 @@
         /// Can't be accessed by users that aren't admins.
         /// </summary>
         /// <param name="model"></param>
+        /// <param name="isUserAdmin">
+        /// Temporary param for test controller.
+        /// Otherwise an error for no instance of CLaimsPrincpialExtensions.IsAdmin().
+        /// </param>
         /// <returns>Admin product panel on successful add. Otherwise, the user can try to add the product again.</returns>
         [HttpPost]
         public async Task<IActionResult> Add(ProductFormViewModel model, bool isUserAdmin)
@@ -91,6 +99,10 @@
         /// Get request for editing a product.
         /// </summary>
         /// <param name="id">Id for the product that the admin wants to edit.</param>
+        /// <param name="isUserAdmin">
+        /// Temporary param for test controller.
+        /// Otherwise an error for no instance of CLaimsPrincpialExtensions.IsAdmin().
+        /// </param>
         /// <returns>Post request with model to edit.</returns>
         [HttpGet]
         public async Task<IActionResult> Edit(int id, bool isUserAdmin)
@@ -121,6 +133,10 @@
         /// Post request for editing a product.
         /// </summary>
         /// <param name="model">View model with validations.</param>
+        /// <param name="isUserAdmin">
+        /// Temporary param for test controller.
+        /// Otherwise an error for no instance of CLaimsPrincpialExtensions.IsAdmin().
+        /// </param>
         /// <returns>If model is valid, user is redirected to admin category panel. Otherwise, they are prompted to edit the name again.</returns>
         [HttpPost]
         public async Task<IActionResult> Edit(ProductFormViewModel model, bool isUserAdmin)
@@ -146,6 +162,10 @@
         /// Delete product from the list.
         /// </summary>
         /// <param name="id">Id of product that will be deleted.</param>
+        /// <param name="isUserAdmin">
+        /// Temporary param for test controller.
+        /// Otherwise an error for no instance of CLaimsPrincpialExtensions.IsAdmin().
+        /// </param>
         /// <returns>Returns to panel page if successful.</returns>
         public async Task<IActionResult> Delete(int id, bool isUserAdmin)
         {
@@ -164,6 +184,10 @@
         /// Restore a product to the list.
         /// </summary>
         /// <param name="id">Id of product that will be restored.</param>
+        /// <param name="isUserAdmin">
+        /// Temporary param for test controller.
+        /// Otherwise an error for no instance of CLaimsPrincpialExtensions.IsAdmin().
+        /// </param>
         /// <returns>Returns to panel page if successful.</returns>
         public async Task<IActionResult> Restore(int id, bool isUserAdmin)
         {

--- a/techIE.UnitTests/TestControllers/Areas/Admin/ProductTestController.cs
+++ b/techIE.UnitTests/TestControllers/Areas/Admin/ProductTestController.cs
@@ -22,7 +22,6 @@
         private readonly string testUserId = "fake-guid-id";
         private readonly IProductService productService;
         private readonly ICategoryService categoryService;
-        private readonly bool isTestUserAdmin = true;
 
         public ProductTestController(
             IProductService _productService,
@@ -38,9 +37,9 @@
         /// </summary>
         /// <returns>Model to add to post request.</returns>
         [HttpGet]
-        public async Task<IActionResult> Add()
+        public async Task<IActionResult> Add(bool isUserAdmin)
         {
-            if (!isTestUserAdmin)
+            if (!isUserAdmin)
             {
                 return Unauthorized();
             }
@@ -50,7 +49,7 @@
                 Categories = await categoryService.GetOfficialAsync()
             };
 
-            if (model.Categories.Any())
+            if (!model.Categories.Any())
             {
                 return RedirectToAction(
                     RedirectPaths.NoAvailableCategoriesPage,
@@ -67,9 +66,9 @@
         /// <param name="model"></param>
         /// <returns>Admin product panel on successful add. Otherwise, the user can try to add the product again.</returns>
         [HttpPost]
-        public async Task<IActionResult> Add(ProductFormViewModel model)
+        public async Task<IActionResult> Add(ProductFormViewModel model, bool isUserAdmin)
         {
-            if (isTestUserAdmin)
+            if (!isUserAdmin)
             {
                 return Unauthorized();
             }
@@ -94,9 +93,9 @@
         /// <param name="id">Id for the product that the admin wants to edit.</param>
         /// <returns>Post request with model to edit.</returns>
         [HttpGet]
-        public async Task<IActionResult> Edit(int id)
+        public async Task<IActionResult> Edit(int id, bool isUserAdmin)
         {
-            if (isTestUserAdmin)
+            if (!isUserAdmin)
             {
                 return Unauthorized();
             }
@@ -124,9 +123,9 @@
         /// <param name="model">View model with validations.</param>
         /// <returns>If model is valid, user is redirected to admin category panel. Otherwise, they are prompted to edit the name again.</returns>
         [HttpPost]
-        public async Task<IActionResult> Edit(ProductFormViewModel model)
+        public async Task<IActionResult> Edit(ProductFormViewModel model, bool isUserAdmin)
         {
-            if (isTestUserAdmin)
+            if (!isUserAdmin)
             {
                 return Unauthorized();
             }
@@ -148,9 +147,9 @@
         /// </summary>
         /// <param name="id">Id of product that will be deleted.</param>
         /// <returns>Returns to panel page if successful.</returns>
-        public async Task<IActionResult> Delete(int id)
+        public async Task<IActionResult> Delete(int id, bool isUserAdmin)
         {
-            if (isTestUserAdmin)
+            if (!isUserAdmin)
             {
                 return Unauthorized();
             }
@@ -166,9 +165,9 @@
         /// </summary>
         /// <param name="id">Id of product that will be restored.</param>
         /// <returns>Returns to panel page if successful.</returns>
-        public async Task<IActionResult> Restore(int id)
+        public async Task<IActionResult> Restore(int id, bool isUserAdmin)
         {
-            if (isTestUserAdmin)
+            if (!isUserAdmin)
             {
                 return Unauthorized();
             }

--- a/techIE.UnitTests/TestControllers/Areas/Admin/ProductTestController.cs
+++ b/techIE.UnitTests/TestControllers/Areas/Admin/ProductTestController.cs
@@ -1,0 +1,182 @@
+﻿namespace techIE.UnitTests.TestControllers.Areas.Admin
+{
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    using Microsoft.AspNetCore.Mvc;
+
+    using Constants;
+    using Contracts;
+
+    using Models.Products;
+
+    using techIE.Controllers;
+
+    /// <summary>
+    /// Controller for managing the official products from the admin product panel.
+    /// </summary>
+    [Area("Admin")]
+    public class ProductTestController : BaseController
+    {
+        // Specifying this here, because I can't test the static ClaimsPrincipalExtensions User.Id().
+        private readonly string testUserId = "fake-guid-id";
+        private readonly IProductService productService;
+        private readonly ICategoryService categoryService;
+        private readonly bool isTestUserAdmin = true;
+
+        public ProductTestController(
+            IProductService _productService,
+            ICategoryService _categoryService)
+        {
+            productService = _productService;
+            categoryService = _categoryService;
+        }
+
+        /// <summary>
+        /// Get request for adding a product from the admin product panel.
+        /// Can't be accessed by users that aren't admins.
+        /// </summary>
+        /// <returns>Model to add to post request.</returns>
+        [HttpGet]
+        public async Task<IActionResult> Add()
+        {
+            if (!isTestUserAdmin)
+            {
+                return Unauthorized();
+            }
+
+            var model = new ProductFormViewModel()
+            {
+                Categories = await categoryService.GetOfficialAsync()
+            };
+
+            if (model.Categories.Any())
+            {
+                return RedirectToAction(
+                    RedirectPaths.NoAvailableCategoriesPage,
+                    RedirectPaths.NoAvailableCategoriesController);
+            }
+
+            return View(model);
+        }
+
+        /// <summary>
+        /// Post request for adding a product to the database.
+        /// Can't be accessed by users that aren't admins.
+        /// </summary>
+        /// <param name="model"></param>
+        /// <returns>Admin product panel on successful add. Otherwise, the user can try to add the product again.</returns>
+        [HttpPost]
+        public async Task<IActionResult> Add(ProductFormViewModel model)
+        {
+            if (isTestUserAdmin)
+            {
+                return Unauthorized();
+            }
+
+            if (!ModelState.IsValid)
+            {
+                model.Categories = await categoryService.GetOfficialAsync();
+                return View(model);
+            }
+
+            // Since this controller is in the Admin area, the added products are always official.
+            model.IsOfficial = true;
+            await productService.AddAsync(model, testUserId);
+            return RedirectToAction(
+                RedirectPaths.UpdateProductPage,
+                RedirectPaths.UpdateProductController);
+        }
+
+        /// <summary>
+        /// Get request for editing a product.
+        /// </summary>
+        /// <param name="id">Id for the product that the admin wants to edit.</param>
+        /// <returns>Post request with model to edit.</returns>
+        [HttpGet]
+        public async Task<IActionResult> Edit(int id)
+        {
+            if (isTestUserAdmin)
+            {
+                return Unauthorized();
+            }
+
+            var model = await productService.GetFormModelAsync(id);
+            if (model == null)
+            {
+                return NotFound();
+            }
+
+            model.Categories = await categoryService.GetOfficialAsync();
+            if (!model.Categories.Any())
+            {
+                return RedirectToAction(
+                    RedirectPaths.NoAvailableCategoriesPage,
+                    RedirectPaths.NoAvailableCategoriesController);
+            }
+
+            return View(model);
+        }
+
+        /// <summary>
+        /// Post request for editing a product.
+        /// </summary>
+        /// <param name="model">View model with validations.</param>
+        /// <returns>If model is valid, user is redirected to admin category panel. Otherwise, they are prompted to edit the name again.</returns>
+        [HttpPost]
+        public async Task<IActionResult> Edit(ProductFormViewModel model)
+        {
+            if (isTestUserAdmin)
+            {
+                return Unauthorized();
+            }
+
+            if (!ModelState.IsValid)
+            {
+                model.Categories = await categoryService.GetOfficialAsync();
+                return View(model);
+            }
+
+            await productService.EditAsync(model);
+            return RedirectToAction(
+                RedirectPaths.UpdateProductPage,
+                RedirectPaths.UpdateProductController);
+        }
+
+        /// <summary>
+        /// Delete product from the list.
+        /// </summary>
+        /// <param name="id">Id of product that will be deleted.</param>
+        /// <returns>Returns to panel page if successful.</returns>
+        public async Task<IActionResult> Delete(int id)
+        {
+            if (isTestUserAdmin)
+            {
+                return Unauthorized();
+            }
+
+            await productService.DeleteAsync(id);
+            return RedirectToAction(
+                RedirectPaths.UpdateProductPage,
+                RedirectPaths.UpdateProductController);
+        }
+
+        /// <summary>
+        /// Restore a product to the list.
+        /// </summary>
+        /// <param name="id">Id of product that will be restored.</param>
+        /// <returns>Returns to panel page if successful.</returns>
+        public async Task<IActionResult> Restore(int id)
+        {
+            if (isTestUserAdmin)
+            {
+                return Unauthorized();
+            }
+
+            await productService.RestoreAsync(id);
+            return RedirectToAction(
+                RedirectPaths.UpdateProductPage,
+                RedirectPaths.UpdateProductController);
+        }
+    }
+}

--- a/techIE.UnitTests/TestControllers/Areas/Marketplace/ProductTestController.cs
+++ b/techIE.UnitTests/TestControllers/Areas/Marketplace/ProductTestController.cs
@@ -1,0 +1,206 @@
+﻿namespace techIE.Areas.Marketplace.Controllers
+{
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    using Microsoft.AspNetCore.Mvc;
+
+    using Constants;
+    using Contracts;
+    using Infrastructure;
+
+    using Models.Products;
+
+    using techIE.Controllers;
+
+    /// <summary>
+    /// Product controller for user marketplace.
+    /// Users can add products, view their details and make orders.
+    /// </summary>
+    [Area("Marketplace")]
+    public class ProductTestController : BaseController
+    {
+        private readonly IUserService userService;
+        private readonly IProductService productService;
+        private readonly ICategoryService categoryService;
+        private readonly string testUserId = "fake-guid-id";
+
+        public ProductTestController(
+            IUserService _userService,
+            IProductService _productService,
+            ICategoryService _categoryService)
+        {
+            userService = _userService;
+            productService = _productService;
+            categoryService = _categoryService;
+        }
+
+        /// <summary>
+        /// Adding a product to the user marketplace.
+        /// Any logged in user can do this.
+        /// </summary>
+        [HttpGet]
+        public async Task<IActionResult> Add()
+        {
+            var model = new ProductFormViewModel
+            {
+                Categories = await categoryService.GetAllAvailableAsync()
+            };
+
+            if (model.Categories.Count() == 0)
+            {
+                return RedirectToAction(
+                    RedirectPaths.NoMarketplaceCategoriesPage,
+                    RedirectPaths.NoMarketplaceCategoriesController);
+            }
+
+            return View(model);
+        }
+
+        /// <summary>
+        /// Adds a product to the user marketplace if the model is valid.
+        /// IsOfficial is always false, as the product is just for the marketplace.
+        /// </summary>
+        /// <param name="model">Product that we are adding to the marketplace.</param>
+        /// <returns>Redirects to marketplace index page if successful. Otherwise, the user is promted to enter their product again.</returns>
+        [HttpPost]
+        public async Task<IActionResult> Add(ProductFormViewModel model)
+        {
+            if (!ModelState.IsValid)
+            {
+                model.Categories = await categoryService.GetAllAvailableAsync();
+                return View(model);
+            }
+
+            // As this product is added in the user marketplace it's not considered one of techIE's official products.
+            model.IsOfficial = false;
+            await productService.AddAsync(model, testUserId);
+            return RedirectToAction(
+                RedirectPaths.AddMarketplaceProductPage,
+                RedirectPaths.AddMarketplaceProductController);
+        }
+
+        /// <summary>
+        /// Product details for marketplace products.
+        /// </summary>
+        /// <param name="id">Id of the product the user wants to see.</param>
+        /// <returns>Page with more details about the selected product.</returns>
+        [HttpGet]
+        public async Task<IActionResult> Details(int id)
+        {
+            var seller = await userService.GetUserByProductIdAsync(id);
+            if (seller == null)
+            {
+                return BadRequest();
+            }
+
+            var model = await productService.GetDetailedAsync(id, seller);
+            if (model == null || model.IsDeleted)
+            {
+                return NotFound();
+            }
+
+            // Redirects the user to the Official area, if the product is official.
+            if (model.IsOfficial)
+            {
+                return RedirectToAction(
+                    RedirectPaths.ProductIsOfficialPage,
+                    RedirectPaths.ProductIsOfficialController,
+                    new { id = model.Id, area = RedirectPaths.ProductIsOfficialArea });
+            }
+
+            return View(model);
+        }
+
+        /// <summary>
+        /// Edit a product which the user has created.
+        /// If the user isn't the one who has created the product, 404 is returned.
+        /// </summary>
+        /// <param name="id">Id of the product that is being edited.</param>
+        /// <returns>NotFound if user isn't seller or if product with provided Id doesn't exist. Otherwise proceeds to post request.</returns>
+        [HttpGet]
+        public async Task<IActionResult> Edit(int id)
+        {
+            if (await productService.IsUserSellerAsync(id, testUserId) == false)
+            {
+                return NotFound();
+            }
+
+            var model = await productService.GetFormModelAsync(id);
+            if (model == null)
+            {
+                return NotFound();
+            }
+
+            model.Categories = await categoryService.GetAllAvailableAsync();
+            if (model.Categories.Count() == 0)
+            {
+                return RedirectToAction(
+                    RedirectPaths.NoMarketplaceCategoriesPage,
+                    RedirectPaths.NoMarketplaceCategoriesController);
+            }
+
+            return View(model);
+        }
+
+        /// <summary>
+        /// Edits the marketplace product.
+        /// </summary>
+        /// <param name="model">Product that is being edited passed as a model to visualize on page.</param>
+        /// <returns>The same page if model validations don't pass. Otherwise redirects to the marketplace store index page.</returns>
+        [HttpPost]
+        public async Task<IActionResult> Edit(ProductFormViewModel model)
+        {
+            if (!ModelState.IsValid)
+            {
+                model.Categories = await categoryService.GetAllAvailableAsync();
+                return View(model);
+            }
+
+            await productService.EditAsync(model);
+            return RedirectToAction(
+                RedirectPaths.MarketplaceEditPage,
+                RedirectPaths.MarketplaceEditController);
+        }
+
+        /// <summary>
+        /// Delete product from the marketplace.
+        /// </summary>
+        /// <param name="id">Id of product that will be deleted.</param>
+        /// <returns>Returns to panel page if successful.</returns>
+        public async Task<IActionResult> Delete(int id)
+        {
+            var isSeller = await productService.IsUserSellerAsync(id, testUserId);
+            if (isSeller == false)
+            {
+                return NotFound();
+            }
+
+            await productService.DeleteAsync(id);
+            return RedirectToAction(
+                RedirectPaths.DeleteMarketplaceProductPage,
+                RedirectPaths.DeleteMarketplaceProductController,
+                new { area = "" });
+        }
+
+        /// <summary>
+        /// Restore a product to the marketplace.
+        /// </summary>
+        /// <param name="id">Id of product that will be restored.</param>
+        /// <returns>Returns to panel page if successful.</returns>
+        public async Task<IActionResult> Restore(int id)
+        {
+            var isSeller = await productService.IsUserSellerAsync(id, testUserId);
+            if (isSeller == false)
+            {
+                return NotFound();
+            }
+
+            await productService.RestoreAsync(id);
+            return RedirectToAction(
+                RedirectPaths.DeleteMarketplaceProductPage,
+                RedirectPaths.DeleteMarketplaceProductController,
+                new { area = "" });
+        }
+    }
+}

--- a/techIE.UnitTests/TestControllers/Areas/Marketplace/ProductTestController.cs
+++ b/techIE.UnitTests/TestControllers/Areas/Marketplace/ProductTestController.cs
@@ -1,4 +1,4 @@
-﻿namespace techIE.Areas.Marketplace.Controllers
+﻿namespace techIE.UnitTests.TestControllers.Areas.Marketplace
 {
     using System.Linq;
     using System.Threading.Tasks;
@@ -7,7 +7,6 @@
 
     using Constants;
     using Contracts;
-    using Infrastructure;
 
     using Models.Products;
 
@@ -20,10 +19,11 @@
     [Area("Marketplace")]
     public class ProductTestController : BaseController
     {
+        // Specifying this here, because I can't test the static ClaimsPrincipalExtensions User.Id().
+        private readonly string testUserId = "fake-guid-id";
         private readonly IUserService userService;
         private readonly IProductService productService;
         private readonly ICategoryService categoryService;
-        private readonly string testUserId = "fake-guid-id";
 
         public ProductTestController(
             IUserService _userService,
@@ -47,7 +47,7 @@
                 Categories = await categoryService.GetAllAvailableAsync()
             };
 
-            if (model.Categories.Count() == 0)
+            if (!model.Categories.Any())
             {
                 return RedirectToAction(
                     RedirectPaths.NoMarketplaceCategoriesPage,
@@ -133,7 +133,7 @@
             }
 
             model.Categories = await categoryService.GetAllAvailableAsync();
-            if (model.Categories.Count() == 0)
+            if (!model.Categories.Any())
             {
                 return RedirectToAction(
                     RedirectPaths.NoMarketplaceCategoriesPage,

--- a/techIE.UnitTests/TestControllers/CartTestController.cs
+++ b/techIE.UnitTests/TestControllers/CartTestController.cs
@@ -7,7 +7,6 @@
     using techIE.Controllers;
     using techIE.Constants;
     using techIE.Contracts;
-    using techIE.Infrastructure;
     using techIE.Data.Entities.Enums;
 
     /// <summary>

--- a/techIE.UnitTests/TestControllers/CartTestController.cs
+++ b/techIE.UnitTests/TestControllers/CartTestController.cs
@@ -15,8 +15,9 @@
     /// </summary>
     public class CartTestController : BaseController
     {
+        // Specifying this here, because I can't test the static ClaimsPrincipalExtensions User.Id().
+        private readonly string testUserId = "fake-guid"; 
         private readonly ICartService cartService;
-        private string testUserId = "fake-guid"; // Specifying this here, because I can't test the static ClaimsPrincipalExtensions User.Id().
 
         public CartTestController(
             ICartService _cartService)

--- a/techIE.UnitTests/TestControllers/CartTestController.cs
+++ b/techIE.UnitTests/TestControllers/CartTestController.cs
@@ -1,0 +1,118 @@
+﻿namespace techIE.UnitTests.TestControllers
+{
+    using System.Threading.Tasks;
+
+    using Microsoft.AspNetCore.Mvc;
+
+    using techIE.Controllers;
+    using techIE.Constants;
+    using techIE.Contracts;
+    using techIE.Infrastructure;
+    using techIE.Data.Entities.Enums;
+
+    /// <summary>
+    /// Controller used for managing carts.
+    /// Used in both official and marketplace areas.
+    /// </summary>
+    public class CartTestController : BaseController
+    {
+        private readonly ICartService cartService;
+        private string testUserId = "fake-guid"; // Specifying this here, because I can't test the static ClaimsPrincipalExtensions User.Id().
+
+        public CartTestController(
+            ICartService _cartService)
+        {
+            cartService = _cartService;
+        }
+
+        /// <summary>
+        /// Add product to current cart.
+        /// </summary>
+        /// <param name="id">Id of product that is being added.</param>
+        /// <param name="store">Store can be Official or Marketplace, depending on where the product is being added from.</param>
+        /// <returns>Depending on the enum CartAction, the user is either redirected to an appropriate page or gets BadRequest.</returns>
+        public async Task<IActionResult> Add(int id, string store)
+        {
+            var action = await cartService.AddProductAsync(id, testUserId);
+
+            if (action == CartAction.Failed)
+            {
+                return BadRequest();
+            }
+
+            if (action == CartAction.Successful)
+            {
+                TempData["Cart"] = Messages.CartActionSuccessful;
+            }
+            else if (action == CartAction.Duplicate)
+            {
+                TempData["Cart"] = Messages.CartActionDuplicate;
+            }
+
+            return RedirectToAction(
+                    RedirectPaths.AddProductToOrderPage,
+                    RedirectPaths.AddProductToOrderController,
+                    new { area = store });
+        }
+
+        /// <summary>
+        /// Inspects the cart. 
+        /// The user can view all currently added products, increase their quantity or remove them.
+        /// </summary>
+        /// <returns>Cart content if there are items in the cart. Otherwise, the user is informed that their cart is empty..</returns>
+        public async Task<IActionResult> Inspect()
+        {
+            var model = await cartService.GetCurrentCartAsync(testUserId);
+            return View(model);
+        }
+
+        /// <summary>
+        /// Removes a product from the cart.
+        /// If product quanity is more than 1, it only reduces the total quantity.
+        /// </summary>
+        /// <param name="cartId">Id of cart from which we are removing a product.</param>
+        /// <param name="productId">Product which we are removing/reducing.</param>
+        /// <returns>Redirects to the cart inspect page.</returns>
+        public async Task<IActionResult> Remove(int cartId, int productId)
+        {
+            if (await cartService.IsCartForUserAsync(cartId, testUserId) == false)
+            {
+                return NotFound();
+            }
+
+            await cartService.RemoveProductAsync(cartId, productId);
+            return RedirectToAction(
+                RedirectPaths.CartInspectPage,
+                RedirectPaths.CartInspectController);
+        }
+
+        /// <summary>
+        /// Empties out the cart. No products are left, despite their quantity.
+        /// </summary>
+        /// <param name="cartId">Id of cart which we are emptying out.</param>
+        /// <returns>Redirects to the cart inspect page.</returns>
+        public async Task<IActionResult> Empty(int cartId)
+        {
+            if (await cartService.IsCartForUserAsync(cartId, testUserId) == false)
+            {
+                return NotFound();
+            }
+
+            await cartService.RemoveAllProductsAsync(cartId);
+            return RedirectToAction(
+                RedirectPaths.CartInspectPage,
+                RedirectPaths.CartInspectController);
+        }
+
+        public async Task<IActionResult> History(int cartId) 
+        {
+            if (await cartService.IsCartForUserAsync(cartId, testUserId) == false)
+            {
+                return NotFound();
+            }
+
+            var model = await cartService.GetCartAsync(cartId);
+            return View(model);
+        }
+    }
+}

--- a/techIE.UnitTests/TestControllers/OrderTestController.cs
+++ b/techIE.UnitTests/TestControllers/OrderTestController.cs
@@ -1,0 +1,53 @@
+﻿namespace techIE.UnitTests.TestControllers
+{
+    using System.Threading.Tasks;
+
+    using Microsoft.AspNetCore.Mvc;
+
+    using techIE.Controllers;
+    using techIE.Constants;
+    using techIE.Contracts;
+
+    /// <summary>
+    /// Controller for managing orders.
+    /// Used in both official and marketplace area.
+    /// </summary>
+    public class OrderTestController : BaseController
+    {
+        private readonly ICartService cartService;
+        private readonly IOrderService orderService;
+        private string testUserId = "fake-guid"; // Specifying this here, because I can't test the static ClaimsPrincipalExtensions User.Id().
+
+        public OrderTestController(
+            ICartService _cartService,
+            IOrderService _orderService)
+        {
+            cartService = _cartService;
+            orderService = _orderService;
+        }
+
+        /// <summary>
+        /// Checkout the products in the current cart of the user.
+        /// </summary>
+        /// <param name="cartId">The cart that is being finalized.</param>
+        /// <returns>Redirects the user to their order history page.</returns>
+        public async Task<IActionResult> Finish(int cartId)
+        {
+            if (await cartService.IsCartForUserAsync(cartId, testUserId) == false)
+            {
+                return NotFound();
+            }
+
+            await orderService.FinishAsync(cartId);
+            return RedirectToAction(
+                RedirectPaths.FinishOrderPage,
+                RedirectPaths.FinishOrderController);
+        }
+
+        public async Task<IActionResult> History()
+        {
+            var model = await orderService.GetHistoryAsync(testUserId);
+            return View(model);
+        }
+    }
+}

--- a/techIE.UnitTests/TestControllers/OrderTestController.cs
+++ b/techIE.UnitTests/TestControllers/OrderTestController.cs
@@ -14,9 +14,10 @@
     /// </summary>
     public class OrderTestController : BaseController
     {
+        // Specifying this here, because I can't test the static ClaimsPrincipalExtensions User.Id().
+        private readonly string testUserId = "fake-guid"; 
         private readonly ICartService cartService;
         private readonly IOrderService orderService;
-        private string testUserId = "fake-guid"; // Specifying this here, because I can't test the static ClaimsPrincipalExtensions User.Id().
 
         public OrderTestController(
             ICartService _cartService,

--- a/techIE.UnitTests/techIE.UnitTests.csproj
+++ b/techIE.UnitTests/techIE.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -18,11 +18,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\techIE\techIE.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Areas\" />
-    <Folder Include="Controllers\" />
   </ItemGroup>
 
 </Project>

--- a/techIE/Areas/Admin/Controllers/CategoryController.cs
+++ b/techIE/Areas/Admin/Controllers/CategoryController.cs
@@ -15,14 +15,10 @@
     [Area("Admin")]
     public class CategoryController : BaseController
     {
-        private readonly IUserService userService;
         private readonly ICategoryService categoryService;
 
-        public CategoryController(
-            IUserService _userService,
-            ICategoryService _categoryService)
+        public CategoryController(ICategoryService _categoryService)
         {
-            userService = _userService;
             categoryService = _categoryService;
         }
 

--- a/techIE/Areas/Admin/Controllers/PanelController.cs
+++ b/techIE/Areas/Admin/Controllers/PanelController.cs
@@ -88,7 +88,7 @@
             }
 
             var officialCategories = await categoryService.GetOfficialAsync();
-            if (officialCategories.Count() > 0)
+            if (officialCategories.Any())
             {
                 return BadRequest();
             }

--- a/techIE/Areas/Admin/Controllers/ProductController.cs
+++ b/techIE/Areas/Admin/Controllers/ProductController.cs
@@ -45,7 +45,7 @@
                 Categories = await categoryService.GetOfficialAsync()
             };
 
-            if (model.Categories.Count() == 0)
+            if (!model.Categories.Any())
             {
                 return RedirectToAction(
                     RedirectPaths.NoAvailableCategoriesPage,
@@ -103,7 +103,7 @@
             }
 
             model.Categories = await categoryService.GetOfficialAsync();
-            if (model.Categories.Count() == 0)
+            if (!model.Categories.Any())
             {
                 return RedirectToAction(
                     RedirectPaths.NoAvailableCategoriesPage,

--- a/techIE/Areas/Marketplace/Controllers/ProductController.cs
+++ b/techIE/Areas/Marketplace/Controllers/ProductController.cs
@@ -43,7 +43,7 @@
                 Categories = await categoryService.GetAllAvailableAsync()
             };
 
-            if (model.Categories.Count() == 0)
+            if (!model.Categories.Any())
             {
                 return RedirectToAction(
                     RedirectPaths.NoMarketplaceCategoriesPage,
@@ -129,7 +129,7 @@
             }
 
             model.Categories = await categoryService.GetAllAvailableAsync();
-            if (model.Categories.Count() == 0)
+            if (!model.Categories.Any())
             {
                 return RedirectToAction(
                     RedirectPaths.NoMarketplaceCategoriesPage,

--- a/techIE/Areas/Marketplace/Controllers/StoreController.cs
+++ b/techIE/Areas/Marketplace/Controllers/StoreController.cs
@@ -69,7 +69,7 @@
         public async Task<IActionResult> Empty()
         {
             var categories = await categoryService.GetAllAvailableAsync();
-            if (categories.Count() > 0)
+            if (categories.Any())
             {
                 return BadRequest();
             }

--- a/techIE/Controllers/CartController.cs
+++ b/techIE/Controllers/CartController.cs
@@ -14,14 +14,11 @@
     public class CartController : BaseController
     {
         private readonly ICartService cartService;
-        private readonly IProductService productService;
 
         public CartController(
-            ICartService _cartService,
-            IProductService _productService)
+            ICartService _cartService)
         {
             cartService = _cartService;
-            productService = _productService;
         }
 
         /// <summary>

--- a/techIE/Infrastructure/ClaimsPrincipalExtensions.cs
+++ b/techIE/Infrastructure/ClaimsPrincipalExtensions.cs
@@ -1,4 +1,5 @@
-﻿namespace techIE.Infrastructure
+﻿#nullable disable
+namespace techIE.Infrastructure
 {
     using System.Security.Claims;
 

--- a/techIE/Services/CartService.cs
+++ b/techIE/Services/CartService.cs
@@ -54,7 +54,7 @@
                 return false;
             }
 
-            return cart.UserId == userId ? true : false;
+            return cart.UserId == userId;
         }
 
         /// <summary>


### PR DESCRIPTION
Added tests to controllers.

Had to create some TestControllers as well. The initial ones used the static ClaimsPrincipalExtensions, which cannot be mocked.
When using the original ones, the code gets to the extension methods User.Id() and User.IsAdmin(), and the error "Object reference not set" happens.